### PR TITLE
FIX minor bug in pair Discovery Service

### DIFF
--- a/cmd/services/pairDiscoveryService/main.go
+++ b/cmd/services/pairDiscoveryService/main.go
@@ -89,7 +89,7 @@ func updateExchangePairs() {
 			go func(s scrapers.APIScraper, e string) {
 				time.Sleep(5 * time.Second)
 				log.Error("Closing scrapper: " + e)
-
+				s.Close()
 			}(s, e)
 		} else {
 			log.Error("Error creating APIScraper forexchange:" + e)


### PR DESCRIPTION
I forgot the call to the `s.close()` function. Sorry