### PR TITLE
add scraper for bittrex exchange

### DIFF
--- a/config/Bittrex.json
+++ b/config/Bittrex.json
@@ -1,0 +1,254 @@
+{
+  "Coins": [
+    {
+      "Symbol": "ETH",
+      "ForeignName" : "ETH-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "XRP",
+      "ForeignName" : "XRP-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "XRP",
+      "ForeignName" : "XRP-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "BAT",
+      "ForeignName" : "BAT-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "NEO",
+      "ForeignName" : "NEO-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "DASH",
+      "ForeignName" : "DASH-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ADA",
+      "ForeignName" : "ADA-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "OMG",
+      "ForeignName" : "OMG-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "TRX",
+      "ForeignName" : "TRX-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ETC",
+      "ForeignName" : "ETC-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "REP",
+      "ForeignName" : "REP-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "SNT",
+      "ForeignName" : "SNT-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "BNT",
+      "ForeignName" : "BNT-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "MCO",
+      "ForeignName" : "MCO-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ENG",
+      "ForeignName" : "ENG-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "TUSD",
+      "ForeignName" : "TUSD-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ZEC",
+      "ForeignName" : "ZEC-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "LTC",
+      "ForeignName" : "LTC-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "XMR",
+      "ForeignName" : "XMR-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "QTUM",
+      "ForeignName" : "QTUM-ETH",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "BAT",
+      "ForeignName" : "BAT-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "DOGE",
+      "ForeignName" : "DOGE-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ADA",
+      "ForeignName" : "ADA-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "XMR",
+      "ForeignName" : "XMR-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "LTC",
+      "ForeignName" : "LTC-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ZEC",
+      "ForeignName" : "ZEC-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "NEO",
+      "ForeignName" : "NEO-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ENG",
+      "ForeignName" : "ENG-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "STORJ",
+      "ForeignName" : "STORJ-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "TUSD",
+      "ForeignName" : "TUSD-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "BSV",
+      "ForeignName" : "BSV-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "BTC",
+      "ForeignName" : "BTC-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ETH",
+      "ForeignName" : "ETH-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "XRP",
+      "ForeignName" : "XRP-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "TUSD",
+      "ForeignName" : "TUSD-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "TRX",
+      "ForeignName" : "TRX-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "NEO",
+      "ForeignName" : "NEO-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ZEC",
+      "ForeignName" : "ZEC-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "LTC",
+      "ForeignName" : "LTC-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ADA",
+      "ForeignName" : "ADA-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "XMR",
+      "ForeignName" : "XMR-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ETC",
+      "ForeignName" : "ETC-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "DASH",
+      "ForeignName" : "DASH-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "DOGE",
+      "ForeignName" : "DOGE-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "OMG",
+      "ForeignName" : "OMG-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "BAT",
+      "ForeignName" : "BAT-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "ZRX",
+      "ForeignName" : "ZRX-USDT",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "DTA",
+      "ForeignName" : "DTA-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "SRN",
+      "ForeignName" : "SRN-BTC",
+      "Exchange" : "Bittrex"
+    },
+    {
+      "Symbol": "FCT",
+      "ForeignName" : "FCT-BTC",
+      "Exchange" : "Bittrex"
+    }
+  ]
+}

--- a/deployments/docker-compose.exchange-scrapers.yml
+++ b/deployments/docker-compose.exchange-scrapers.yml
@@ -51,6 +51,19 @@ services:
       options:
         max-size: "50m"
 
+  bittrexcollector:
+    build:
+      context: ../../../..
+      dockerfile: github.com/diadata-org/diadata/build/Dockerfile-genericCollector
+    image: ${DOCKER_HUB_LOGIN}/${STACKNAME}_bittrexcollector:latest
+    command: /bin/collector -exchange=Bittrex
+    networks:
+      - kafka-network
+      - redis-network
+    logging:
+      options:
+        max-size: "50m"
+
   lbankcollector:
     build:
       context: ../../../..
@@ -58,7 +71,7 @@ services:
     image: ${DOCKER_HUB_LOGIN}/${STACKNAME}_lbankcollector:latest
     command: /bin/collector -exchange=LBank
     networks:
-      - kafka-network      
+      - kafka-network
       - redis-network
     logging:
       options:
@@ -158,7 +171,7 @@ services:
     logging:
       options:
         max-size: "50m"
-  
+
   quoinecollector:
     build:
       context: ../../../..
@@ -179,7 +192,7 @@ secrets:
     file: ../secrets/api_bitfinex.json
   api_kraken:
     file: ../secrets/api_kraken.json
-      
+
 networks:
   kafka-network:
     external:

--- a/internal/pkg/exchange-scrapers/APIScraper.go
+++ b/internal/pkg/exchange-scrapers/APIScraper.go
@@ -1,8 +1,9 @@
 package scrapers
 
 import (
-	"github.com/diadata-org/diadata/pkg/dia"
 	"io"
+
+	"github.com/diadata-org/diadata/pkg/dia"
 )
 
 // empty type used for signaling
@@ -40,6 +41,8 @@ func NewAPIScraper(exchange string, key string, secret string) APIScraper {
 		return NewBinanceScraper(key, secret, dia.BinanceExchange)
 	case dia.BitfinexExchange:
 		return NewBitfinexScraper(key, secret, dia.BitfinexExchange)
+	case dia.BittrexExchange:
+		return NewBittrexScraper(dia.BittrexExchange)
 	case dia.CoinBaseExchange:
 		return NewCoinBaseScraper(dia.CoinBaseExchange)
 	case dia.KrakenExchange:

--- a/internal/pkg/exchange-scrapers/BittrexScraper.go
+++ b/internal/pkg/exchange-scrapers/BittrexScraper.go
@@ -67,7 +67,7 @@ func (s *BittrexScraper) mainLoop() {
 		}
 		for key, el := range s.pairScrapers {
 
-			// more or less 60 calls per minute, the limit is 300
+			// more or less 60 calls per minute, the limit is 60
 			time.Sleep(1 * time.Second)
 
 			//swap the pairs name, necessary for api call

--- a/internal/pkg/exchange-scrapers/BittrexScraper.go
+++ b/internal/pkg/exchange-scrapers/BittrexScraper.go
@@ -1,0 +1,265 @@
+package scrapers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/diadata-org/diadata/pkg/dia"
+	"github.com/diadata-org/diadata/pkg/dia/helpers"
+	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+	"net/http"
+	"strings"
+  "strconv"
+	"sync"
+	"time"
+)
+
+
+type ConfirmData struct {
+	Result []interface{} `json:"result"`
+  Success bool `json:"success"`
+  Message string `json:"message"`
+}
+
+var _bittrexapiurl string = "https://api.bittrex.com/api/v1.1/public"
+
+type BittrexScraper struct {
+	// signaling channels for session initialization and finishing
+	run          bool
+	shutdown     chan nothing
+	shutdownDone chan nothing
+	// error handling; to read error or closed, first acquire read lock
+	// only cleanup method should hold write lock
+	errorLock sync.RWMutex
+	error     error
+	closed    bool
+	// used to keep track of trading pairs that we subscribed to
+	pairScrapers map[string]*BittrexPairScraper
+	exchangeName string
+}
+
+func NewBittrexScraper(exchangeName string) *BittrexScraper {
+	s := &BittrexScraper{
+		shutdown:     make(chan nothing),
+		shutdownDone: make(chan nothing),
+		pairScrapers: make(map[string]*BittrexPairScraper),
+		exchangeName: exchangeName,
+		error:        nil,
+	}
+  p, _ := s.FetchAvailablePairs()
+  fmt.Println(p)
+
+	go s.mainLoop()
+	return s
+}
+
+
+// runs in a goroutine until s is closed
+func (s *BittrexScraper) mainLoop() {
+
+	//wait for all pairscrapers have been created
+	time.Sleep(7 * time.Second)
+	layout := "2006-01-02T15:04:05"
+	s.run = true
+	for s.run {
+		if len(s.pairScrapers) == 0 {
+			s.error = errors.New("BittrexScraper: No pairs to scrap provided")
+			log.Error(s.error.Error())
+			break
+		}
+		for key, el := range s.pairScrapers {
+
+			// more or less 60 calls per minute, the limit is 300
+			time.Sleep(1 * time.Second)
+
+      //swap the pairs name, necessary for api call
+      sPairs := strings.Split(key,"-")
+      sLeft, sRight := sPairs[0], sPairs[1]
+
+    	pairTrade := getAPICallBittrex("/getmarkethistory?market=" + sRight + "-" + sLeft)
+
+			if len(pairTrade) > 0 {
+				newId := 0
+				atLeastOneUpdate := false
+				for _, elTrade := range pairTrade {
+
+          tradeReturn := elTrade.(map[string]interface{})
+					idInt := int(tradeReturn["Id"].(float64))
+
+					if el.lastIdTrade < idInt {
+						if idInt > newId {
+							newId = idInt
+							atLeastOneUpdate = true
+						}
+
+            f64Price := tradeReturn["Price"].(float64)
+            f64Volume := tradeReturn["Quantity"].(float64)
+
+						if tradeReturn["OrderType"] == "SELL" {
+							f64Volume = -f64Volume
+						}
+
+						timeStamp, _ := time.Parse(layout, tradeReturn["TimeStamp"].(string))
+						t := &dia.Trade{
+							Symbol:         el.pair.Symbol,
+							Pair:           key,
+							Price:          f64Price,
+							Volume:         f64Volume,
+							Time:           timeStamp,
+							ForeignTradeID: strconv.FormatInt(int64(tradeReturn["Id"].(float64)), 16),
+							Source:         s.exchangeName,
+						}
+						el.chanTrades <- t
+					}
+				}
+				if atLeastOneUpdate {
+					el.lastIdTrade = newId
+				}
+			}
+		}
+	}
+	if s.error == nil {
+		s.error = errors.New("BittrexScraper: terminated by Close()")
+	}
+	s.cleanup(s.error)
+}
+
+func getAPICallBittrex(params ...string) []interface{} {
+
+	req, err := http.Get(_bittrexapiurl + params[0])
+	if err != nil {
+		fmt.Println(err)
+	}
+  defer req.Body.Close()
+	body, readErr := ioutil.ReadAll(req.Body)
+	if readErr != nil {
+		fmt.Println(readErr)
+	}
+	confirmTemp := ConfirmData{}
+	jsonErr := json.Unmarshal(body, &confirmTemp)
+	if jsonErr != nil {
+		fmt.Println(jsonErr)
+	}
+  return confirmTemp.Result
+}
+
+func (s *BittrexScraper) cleanup(err error) {
+	s.errorLock.Lock()
+	defer s.errorLock.Unlock()
+	if err != nil {
+		s.error = err
+	}
+	s.closed = true
+	close(s.shutdownDone)
+}
+
+// Close closes any existing API connections, as well as channels of
+// PairScrapers from calls to ScrapePair
+func (s *BittrexScraper) Close() error {
+
+	if s.closed {
+		return errors.New("BittrexScraper: Already closed")
+	}
+	s.run = false
+	close(s.shutdown)
+	<-s.shutdownDone
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+	return s.error
+}
+
+// ScrapePair returns a PairScraper that can be used to get trades for a single pair from
+// this APIScraper
+func (s *BittrexScraper) ScrapePair(pair dia.Pair) (PairScraper, error) {
+
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+
+	if s.error != nil {
+		return nil, s.error
+	}
+
+	if s.closed {
+		return nil, errors.New("BittrexScraper: Call ScrapePair on closed scraper")
+	}
+
+	ps := &BittrexPairScraper{
+		parent:     s,
+		pair:       pair,
+		chanTrades: make(chan *dia.Trade),
+    lastIdTrade: 0,
+	}
+
+	s.pairScrapers[pair.ForeignName] = ps
+
+	return ps, nil
+}
+
+func (s *BittrexScraper) normalizeSymbol(baseCurrency string, name string) (symbol string, err error) {
+	symbol = strings.ToUpper(baseCurrency)
+	if helpers.NameForSymbol(symbol) == symbol {
+		if !helpers.SymbolIsName(symbol) {
+			return symbol, errors.New("Foreign name can not be normalized:" + name + " symbol:" + symbol)
+		}
+	}
+	if helpers.SymbolIsBlackListed(symbol) {
+		return symbol, errors.New("Symbol is black listed:" + symbol)
+	}
+	return symbol, nil
+}
+
+// FetchAvailablePairs returns a list with all available trade pairs
+func (s *BittrexScraper) FetchAvailablePairs() (pairs []dia.Pair, err error) {
+
+  allPairs := getAPICallBittrex("/getmarkets")
+  if len(allPairs) > 0 {
+    for _, p := range allPairs {
+      pairReturn := p.(map[string]interface{})
+      symbol, serr := s.normalizeSymbol(pairReturn["MarketCurrency"].(string), pairReturn["MarketCurrencyLong"].(string))
+      if serr == nil {
+        pairs = append(pairs, dia.Pair{
+          Symbol:      symbol,
+          ForeignName: symbol + "-" + pairReturn["BaseCurrency"].(string),
+          Exchange:    s.exchangeName,
+        })
+        } else {
+          log.Error(serr)
+        }
+      }
+    }
+    return
+}
+
+// BittrexPairScraper implements PairScraper for Bittrex
+type BittrexPairScraper struct {
+	parent     *BittrexScraper
+	pair       dia.Pair
+	chanTrades chan *dia.Trade
+	closed     bool
+  lastIdTrade int
+}
+
+// Close stops listening for trades of the pair associated with s
+func (ps *BittrexPairScraper) Close() error {
+	return nil
+}
+
+// Channel returns a channel that can be used to receive trades
+func (ps *BittrexPairScraper) Channel() chan *dia.Trade {
+	return ps.chanTrades
+}
+
+// Error returns an error when the channel Channel() is closed
+// and nil otherwise
+func (ps *BittrexPairScraper) Error() error {
+	s := ps.parent
+	s.errorLock.RLock()
+	defer s.errorLock.RUnlock()
+	return s.error
+}
+
+// Pair returns the pair this scraper is subscribed to
+func (ps *BittrexPairScraper) Pair() dia.Pair {
+	return ps.pair
+}

--- a/pkg/dia/Config.go
+++ b/pkg/dia/Config.go
@@ -1,15 +1,17 @@
 package dia
 
 import (
-	"github.com/tkanos/gonfig"
 	"os/user"
 	"strings"
+
+	"github.com/tkanos/gonfig"
 )
 
 const (
 	KrakenExchange   = "Kraken"
 	BitfinexExchange = "Bitfinex"
 	BinanceExchange  = "Binance"
+	BittrexExchange  = "Bittrex"
 	CoinBaseExchange = "CoinBase"
 	HitBTCExchange   = "HitBTC"
 	SimexExchange    = "Simex"
@@ -28,6 +30,7 @@ func Exchanges() []string {
 	return []string{
 		BinanceExchange,
 		BitfinexExchange,
+		BittrexExchange,
 		CoinBaseExchange,
 		GateIOExchange,
 		HitBTCExchange,


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->
- This PR adds a scraper for Bittrex Exchange (Rest API for now).
- It includes 50 pairs.
- It seems that in Bittrex the order of base currency into pair name is inverted. I left as other exchanges in config json, the pair name swaps in code.
- It does 60 API calls per minute (the limit for Bittrex). It can be resolved in the future with ws implementation.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Changes don't break existing behavior

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
--> Fixes: #94 