### PR TITLE
Add sushiswap exchange scrapper

### DIFF
--- a/internal/pkg/exchange-scrapers/APIScraper.go
+++ b/internal/pkg/exchange-scrapers/APIScraper.go
@@ -67,6 +67,8 @@ func NewAPIScraper(exchange string, key string, secret string) APIScraper {
 		return NewBancorScraper(dia.BancorExchange)
 	case dia.UniswapExchange:
 		return NewUniswapScraper(dia.UniswapExchange)
+	case dia.SushiSwapExchange:
+		return NewUniswapScraper(dia.SushiSwapExchange)
 	case dia.LoopringExchange:
 		return NewLoopringScraper(dia.LoopringExchange)
 	case dia.CurveFIExchange:

--- a/internal/pkg/exchange-scrapers/UniswapV2Scraper.go
+++ b/internal/pkg/exchange-scrapers/UniswapV2Scraper.go
@@ -12,10 +12,13 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
-)
 
+)
+var (
+	exchangeFactoryContractAddress = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"
+
+)
 const (
-	uniswapContract = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"
 
 	uniswapsocketurl = "wss://mainnet.infura.io/ws/v3"
 	//uniswapresturl = "https://mainnet.infura.io/v3"
@@ -71,6 +74,15 @@ type UniswapScraper struct {
 // NewUniswapScraper returns a new UniswapScraper for the given pair
 func NewUniswapScraper(exchangeName string) *UniswapScraper {
 
+	switch exchangeName{
+	case dia.UniswapExchange:
+		exchangeFactoryContractAddress="0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac"
+
+		break
+	case dia.SushiSwapExchange:
+		exchangeFactoryContractAddress="0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac"
+	}
+
 	s := &UniswapScraper{
 		shutdown:     make(chan nothing),
 		shutdownDone: make(chan nothing),
@@ -85,7 +97,7 @@ func NewUniswapScraper(exchangeName string) *UniswapScraper {
 		log.Fatal(err)
 	}
 	s.WsClient = wsClient
-	restClient, err := ethclient.Dial(restDial)
+	restClient, err := ethclient.Dial(wsDial)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -232,7 +244,7 @@ func (s *UniswapScraper) FetchAvailablePairs() (pairs []dia.Pair, err error) {
 func (s *UniswapScraper) GetAllPairs() ([]UniswapPair, error) {
 	connection := s.RestClient
 	var contract *uniswapcontract.IUniswapV2FactoryCaller
-	contract, err := uniswapcontract.NewIUniswapV2FactoryCaller(common.HexToAddress(uniswapContract), connection)
+	contract, err := uniswapcontract.NewIUniswapV2FactoryCaller(common.HexToAddress(exchangeFactoryContractAddress), connection)
 	if err != nil {
 		log.Error(err)
 	}
@@ -274,7 +286,7 @@ func (up *UniswapPair) normalizeUniPair() {
 // GetPairByID returns the UniswapPair with the integer id @num
 func (s *UniswapScraper) GetPairByID(num int64) (UniswapPair, error) {
 	var contract *uniswapcontract.IUniswapV2FactoryCaller
-	contract, err := uniswapcontract.NewIUniswapV2FactoryCaller(common.HexToAddress(uniswapContract), s.RestClient)
+	contract, err := uniswapcontract.NewIUniswapV2FactoryCaller(common.HexToAddress(exchangeFactoryContractAddress), s.RestClient)
 	if err != nil {
 		log.Error(err)
 	}
@@ -363,7 +375,7 @@ func (s *UniswapScraper) GetDecimals(tokenAddress common.Address) (decimals uint
 func (s *UniswapScraper) getNumPairs() (int, error) {
 
 	var contract *uniswapcontract.IUniswapV2FactoryCaller
-	contract, err := uniswapcontract.NewIUniswapV2FactoryCaller(common.HexToAddress(uniswapContract), s.RestClient)
+	contract, err := uniswapcontract.NewIUniswapV2FactoryCaller(common.HexToAddress(exchangeFactoryContractAddress), s.RestClient)
 	if err != nil {
 		log.Error(err)
 	}

--- a/internal/pkg/exchange-scrapers/UniswapV2Scraper.go
+++ b/internal/pkg/exchange-scrapers/UniswapV2Scraper.go
@@ -76,7 +76,7 @@ func NewUniswapScraper(exchangeName string) *UniswapScraper {
 
 	switch exchangeName{
 	case dia.UniswapExchange:
-		exchangeFactoryContractAddress="0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac"
+		exchangeFactoryContractAddress="0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"
 
 		break
 	case dia.SushiSwapExchange:

--- a/internal/pkg/exchange-scrapers/UniswapV2Scraper.go
+++ b/internal/pkg/exchange-scrapers/UniswapV2Scraper.go
@@ -97,7 +97,7 @@ func NewUniswapScraper(exchangeName string) *UniswapScraper {
 		log.Fatal(err)
 	}
 	s.WsClient = wsClient
-	restClient, err := ethclient.Dial(wsDial)
+	restClient, err := ethclient.Dial(restDial)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/dia/Config.go
+++ b/pkg/dia/Config.go
@@ -33,6 +33,8 @@ const (
 	CurveFIExchange  = "Curvefi"
 	MakerExchange    = "Maker"
 	KuCoinExchange   = "KuCoin"
+	SushiSwapExchange   = "SushiSwap"
+
 )
 
 func Exchanges() []string {
@@ -59,6 +61,7 @@ func Exchanges() []string {
 		BancorExchange,
 		UnknownExchange,
 		LoopringExchange,
+		SushiSwapExchange,
 	}
 }
 


### PR DESCRIPTION
Sushiswap cannot be added  in lending and buying structure of defi, there will be need of creating structure for farming pools.

This PR takes care of scrapping sushiswap exchange

https://exchange.sushiswapclassic.org/#/swap