### PR TITLE
Adding a exchange scraper for CREX24

### DIFF
--- a/config/CREX24.json
+++ b/config/CREX24.json
@@ -1,0 +1,9556 @@
+{
+    "Coins": [
+        {
+            "Symbol": "$PAC",
+            "ForeignName": "$PAC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "1INCH",
+            "ForeignName": "1INCH-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "1XC",
+            "ForeignName": "1XC-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "2GO",
+            "ForeignName": "2GO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "2X2",
+            "ForeignName": "2X2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "3DC_OLD",
+            "ForeignName": "3DC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "3DC_OLD",
+            "ForeignName": "3DC_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "3DES",
+            "ForeignName": "3DES-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "404_OLD",
+            "ForeignName": "404_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "404",
+            "ForeignName": "404-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "777",
+            "ForeignName": "777-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AAA",
+            "ForeignName": "AAA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ABS",
+            "ForeignName": "ABS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ABULABA",
+            "ForeignName": "ABULABA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ACC_OLD",
+            "ForeignName": "ACC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ACC",
+            "ForeignName": "ACC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ACM",
+            "ForeignName": "ACM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ACV",
+            "ForeignName": "ACV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ADA",
+            "ForeignName": "ADA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ADAI",
+            "ForeignName": "ADAI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ADAST_OLD",
+            "ForeignName": "ADAST_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ADA",
+            "ForeignName": "ADA-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ADE",
+            "ForeignName": "ADE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ADS",
+            "ForeignName": "ADS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ADS",
+            "ForeignName": "ADS-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ADVC",
+            "ForeignName": "ADVC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AE",
+            "ForeignName": "AE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AEG",
+            "ForeignName": "AEG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AEM",
+            "ForeignName": "AEM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AET",
+            "ForeignName": "AET-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AET",
+            "ForeignName": "AET-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AFIN",
+            "ForeignName": "AFIN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AFIN",
+            "ForeignName": "AFIN-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AFIN",
+            "ForeignName": "AFIN-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AFRO",
+            "ForeignName": "AFRO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AGCMN",
+            "ForeignName": "AGCMN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AGET",
+            "ForeignName": "AGET-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AGU",
+            "ForeignName": "AGU-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AGVC",
+            "ForeignName": "AGVC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AIAS",
+            "ForeignName": "AIAS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AIT",
+            "ForeignName": "AIT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AITRA",
+            "ForeignName": "AITRA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AKC",
+            "ForeignName": "AKC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALCUP",
+            "ForeignName": "ALCUP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALIAS",
+            "ForeignName": "ALIAS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALLBI_OLD2",
+            "ForeignName": "ALLBI_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALLBI_OLD2",
+            "ForeignName": "ALLBI_OLD2-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALLBI_OLD3",
+            "ForeignName": "ALLBI_OLD3-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALLBI_OLD3",
+            "ForeignName": "ALLBI_OLD3-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALLBI_OLD",
+            "ForeignName": "ALLBI_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALLBI_OLD",
+            "ForeignName": "ALLBI_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALLBI",
+            "ForeignName": "ALLBI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALLBI",
+            "ForeignName": "ALLBI-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALPS",
+            "ForeignName": "ALPS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALX",
+            "ForeignName": "ALX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALX",
+            "ForeignName": "ALX-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ALX",
+            "ForeignName": "ALX-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AMG",
+            "ForeignName": "AMG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AMG",
+            "ForeignName": "AMG-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AMNZ",
+            "ForeignName": "AMNZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AND",
+            "ForeignName": "AND-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ANDES",
+            "ForeignName": "ANDES-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ANTY",
+            "ForeignName": "ANTY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ANY",
+            "ForeignName": "ANY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ANY",
+            "ForeignName": "ANY-USDC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AOG",
+            "ForeignName": "AOG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "APC",
+            "ForeignName": "APC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "APC",
+            "ForeignName": "APC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "APOT",
+            "ForeignName": "APOT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "APOT",
+            "ForeignName": "APOT-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "APR",
+            "ForeignName": "APR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ARA_OLD",
+            "ForeignName": "ARA_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ARA",
+            "ForeignName": "ARA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AREPA",
+            "ForeignName": "AREPA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ARI",
+            "ForeignName": "ARI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ARION",
+            "ForeignName": "ARION-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ARN_OLD",
+            "ForeignName": "ARN_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ARNX",
+            "ForeignName": "ARNX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ARQ",
+            "ForeignName": "ARQ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ARS",
+            "ForeignName": "ARS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ARTX",
+            "ForeignName": "ARTX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ASAFE",
+            "ForeignName": "ASAFE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AUDAX",
+            "ForeignName": "AUDAX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AUOP",
+            "ForeignName": "AUOP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AUSC",
+            "ForeignName": "AUSC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AXE",
+            "ForeignName": "AXE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AXEL",
+            "ForeignName": "AXEL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AYA",
+            "ForeignName": "AYA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AYA",
+            "ForeignName": "AYA-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AYA",
+            "ForeignName": "AYA-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AZART",
+            "ForeignName": "AZART-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AZR",
+            "ForeignName": "AZR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AZU_OLD",
+            "ForeignName": "AZU_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AZU",
+            "ForeignName": "AZU-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "AZZR",
+            "ForeignName": "AZZR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "B1P",
+            "ForeignName": "B1P-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "B24",
+            "ForeignName": "B24-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "B2C",
+            "ForeignName": "B2C-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "B2N_OLD",
+            "ForeignName": "B2N_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "B2N_OLD",
+            "ForeignName": "B2N_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BAC",
+            "ForeignName": "BAC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BARE_OLD",
+            "ForeignName": "BARE_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BARE",
+            "ForeignName": "BARE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BAT",
+            "ForeignName": "BAT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BAZZ",
+            "ForeignName": "BAZZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BB",
+            "ForeignName": "BB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BB",
+            "ForeignName": "BB-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BBK",
+            "ForeignName": "BBK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BBN",
+            "ForeignName": "BBN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BBS",
+            "ForeignName": "BBS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BBT",
+            "ForeignName": "BBT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCARD",
+            "ForeignName": "BCARD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCASH",
+            "ForeignName": "BCASH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCASH",
+            "ForeignName": "BCASH-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BC",
+            "ForeignName": "BC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCD",
+            "ForeignName": "BCD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCD",
+            "ForeignName": "BCD-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCD",
+            "ForeignName": "BCD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCHA",
+            "ForeignName": "BCHA-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCH",
+            "ForeignName": "BCH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCH",
+            "ForeignName": "BCH-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCH",
+            "ForeignName": "BCH-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCM",
+            "ForeignName": "BCM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCN",
+            "ForeignName": "BCN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCOM",
+            "ForeignName": "BCOM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCP24",
+            "ForeignName": "BCP24-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCP24",
+            "ForeignName": "BCP24-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCP",
+            "ForeignName": "BCP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCPX",
+            "ForeignName": "BCPX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCSN",
+            "ForeignName": "BCSN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCT",
+            "ForeignName": "BCT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCT",
+            "ForeignName": "BCT-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCT",
+            "ForeignName": "BCT-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BCZ",
+            "ForeignName": "BCZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BDCASH",
+            "ForeignName": "BDCASH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BDCC",
+            "ForeignName": "BDCC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BEAR",
+            "ForeignName": "BEAR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BECN_OLD2",
+            "ForeignName": "BECN_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BECN_OLD",
+            "ForeignName": "BECN_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BECN",
+            "ForeignName": "BECN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BEER",
+            "ForeignName": "BEER-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BEET_old",
+            "ForeignName": "BEET_old-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BEET",
+            "ForeignName": "BEET-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BELL",
+            "ForeignName": "BELL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BERG",
+            "ForeignName": "BERG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BETS",
+            "ForeignName": "BETS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BETX",
+            "ForeignName": "BETX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BETXC",
+            "ForeignName": "BETXC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BFC",
+            "ForeignName": "BFC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BFF",
+            "ForeignName": "BFF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BGL",
+            "ForeignName": "BGL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BID",
+            "ForeignName": "BID-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BIK",
+            "ForeignName": "BIK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BIN",
+            "ForeignName": "BIN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BIR",
+            "ForeignName": "BIR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BIT_OLD",
+            "ForeignName": "BIT_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITB",
+            "ForeignName": "BITB-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BIT",
+            "ForeignName": "BIT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITC",
+            "ForeignName": "BITC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITF",
+            "ForeignName": "BITF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITF",
+            "ForeignName": "BITF-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITG_OLD",
+            "ForeignName": "BITG_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITG",
+            "ForeignName": "BITG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITTO_OLD",
+            "ForeignName": "BITTO_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITTO_OLD",
+            "ForeignName": "BITTO_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITTO",
+            "ForeignName": "BITTO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITTO",
+            "ForeignName": "BITTO-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITV",
+            "ForeignName": "BITV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITX",
+            "ForeignName": "BITX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BITX",
+            "ForeignName": "BITX-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BIXCPRO",
+            "ForeignName": "BIXCPRO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BIXCPRO",
+            "ForeignName": "BIXCPRO-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BIXCPRO",
+            "ForeignName": "BIXCPRO-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BKC",
+            "ForeignName": "BKC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BKC",
+            "ForeignName": "BKC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BKC",
+            "ForeignName": "BKC-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BLAST",
+            "ForeignName": "BLAST-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BLN",
+            "ForeignName": "BLN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BLON",
+            "ForeignName": "BLON-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BLT_OLD",
+            "ForeignName": "BLT_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BLT",
+            "ForeignName": "BLT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BNANA_OLD",
+            "ForeignName": "BNANA_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BNANA",
+            "ForeignName": "BNANA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BNB_OLD",
+            "ForeignName": "BNB_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BNB",
+            "ForeignName": "BNB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BNB",
+            "ForeignName": "BNB-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BNN",
+            "ForeignName": "BNN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BNT",
+            "ForeignName": "BNT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BONO",
+            "ForeignName": "BONO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BONO",
+            "ForeignName": "BONO-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BONO",
+            "ForeignName": "BONO-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BOO",
+            "ForeignName": "BOO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BOST",
+            "ForeignName": "BOST-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BPC_OLD",
+            "ForeignName": "BPC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BPC",
+            "ForeignName": "BPC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BPC",
+            "ForeignName": "BPC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BPC",
+            "ForeignName": "BPC-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BPESO",
+            "ForeignName": "BPESO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BPN",
+            "ForeignName": "BPN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BPS",
+            "ForeignName": "BPS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BRG_OLD",
+            "ForeignName": "BRG_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BRG",
+            "ForeignName": "BRG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BRIC",
+            "ForeignName": "BRIC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BRO_OLD",
+            "ForeignName": "BRO_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BRO",
+            "ForeignName": "BRO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BRZC",
+            "ForeignName": "BRZC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BSD",
+            "ForeignName": "BSD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BSD",
+            "ForeignName": "BSD-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BSHN",
+            "ForeignName": "BSHN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BSN_OLD",
+            "ForeignName": "BSN_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BSN",
+            "ForeignName": "BSN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BST",
+            "ForeignName": "BST-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BSV",
+            "ForeignName": "BSV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTAD",
+            "ForeignName": "BTAD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC2",
+            "ForeignName": "BTC2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-BUSD",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTCC_OLD",
+            "ForeignName": "BTCC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-CNY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-EUREP",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-EURT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTCH",
+            "ForeignName": "BTCH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-JPY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTCN",
+            "ForeignName": "BTCN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTCONE",
+            "ForeignName": "BTCONE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-PAX",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTCP",
+            "ForeignName": "BTCP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTCT",
+            "ForeignName": "BTCT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-TUSD",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-UAH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTCU",
+            "ForeignName": "BTCU-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-USDC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-USDEP",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-USDS",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTCZ",
+            "ForeignName": "BTCZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTDX",
+            "ForeignName": "BTDX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTDX",
+            "ForeignName": "BTDX-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTE",
+            "ForeignName": "BTE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTG",
+            "ForeignName": "BTG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTH",
+            "ForeignName": "BTH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTK_OLD2",
+            "ForeignName": "BTK_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTK_OLD",
+            "ForeignName": "BTK_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTK",
+            "ForeignName": "BTK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTLLR",
+            "ForeignName": "BTLLR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTO",
+            "ForeignName": "BTO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTRD",
+            "ForeignName": "BTRD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTRD",
+            "ForeignName": "BTRD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTSA",
+            "ForeignName": "BTSA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTS",
+            "ForeignName": "BTS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTT",
+            "ForeignName": "BTT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTX_OLD",
+            "ForeignName": "BTX_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTX_OLD",
+            "ForeignName": "BTX_OLD-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTX",
+            "ForeignName": "BTX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTXC",
+            "ForeignName": "BTXC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BTX",
+            "ForeignName": "BTX-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BUL",
+            "ForeignName": "BUL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BULL_OLD",
+            "ForeignName": "BULL_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BULL",
+            "ForeignName": "BULL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BUSD",
+            "ForeignName": "BUSD-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BUZZ",
+            "ForeignName": "BUZZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BVK",
+            "ForeignName": "BVK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BWK_OLD",
+            "ForeignName": "BWK_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BWK_OLD",
+            "ForeignName": "BWK_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BWS_OLD",
+            "ForeignName": "BWS_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BXC_OLD",
+            "ForeignName": "BXC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BXC_OLD",
+            "ForeignName": "BXC_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BXC_OLD",
+            "ForeignName": "BXC_OLD-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BYRON_OLD",
+            "ForeignName": "BYRON_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BYRON",
+            "ForeignName": "BYRON-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BZC",
+            "ForeignName": "BZC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BZE",
+            "ForeignName": "BZE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BZK",
+            "ForeignName": "BZK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BZL_OLD",
+            "ForeignName": "BZL_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BZX",
+            "ForeignName": "BZX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "BZZ",
+            "ForeignName": "BZZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "C4L",
+            "ForeignName": "C4L-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CAB",
+            "ForeignName": "CAB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CAC_OLD",
+            "ForeignName": "CAC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CASH",
+            "ForeignName": "CASH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CAT",
+            "ForeignName": "CAT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CATS",
+            "ForeignName": "CATS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CBTC_OLD2",
+            "ForeignName": "CBTC_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CBTC_OLD",
+            "ForeignName": "CBTC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CBTC",
+            "ForeignName": "CBTC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CBX",
+            "ForeignName": "CBX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CCASH",
+            "ForeignName": "CCASH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CCC",
+            "ForeignName": "CCC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CCM_OLD",
+            "ForeignName": "CCM_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CCM",
+            "ForeignName": "CCM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CCTC",
+            "ForeignName": "CCTC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CCY",
+            "ForeignName": "CCY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CDZC",
+            "ForeignName": "CDZC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CELC",
+            "ForeignName": "CELC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CEN",
+            "ForeignName": "CEN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CERT",
+            "ForeignName": "CERT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CFL",
+            "ForeignName": "CFL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CFL",
+            "ForeignName": "CFL-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CGC",
+            "ForeignName": "CGC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CGC",
+            "ForeignName": "CGC-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CGEN_OLD",
+            "ForeignName": "CGEN_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CGEN_OLD",
+            "ForeignName": "CGEN_OLD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CGEN",
+            "ForeignName": "CGEN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CGEN",
+            "ForeignName": "CGEN-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CGEN",
+            "ForeignName": "CGEN-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CGP",
+            "ForeignName": "CGP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CHAN",
+            "ForeignName": "CHAN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CHEESE",
+            "ForeignName": "CHEESE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CHESS",
+            "ForeignName": "CHESS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CHESS",
+            "ForeignName": "CHESS-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CHND_OLD",
+            "ForeignName": "CHND_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CHND",
+            "ForeignName": "CHND-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CHTC",
+            "ForeignName": "CHTC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CIF",
+            "ForeignName": "CIF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CLC",
+            "ForeignName": "CLC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CLR",
+            "ForeignName": "CLR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CMK",
+            "ForeignName": "CMK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CMM_OLD",
+            "ForeignName": "CMM_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CMM",
+            "ForeignName": "CMM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CMT",
+            "ForeignName": "CMT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CMTR_OLD",
+            "ForeignName": "CMTR_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CNCT",
+            "ForeignName": "CNCT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CNMC",
+            "ForeignName": "CNMC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CNT",
+            "ForeignName": "CNT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CNTF",
+            "ForeignName": "CNTF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CNTF",
+            "ForeignName": "CNTF-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CNTX",
+            "ForeignName": "CNTX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "COBRA",
+            "ForeignName": "COBRA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "COF",
+            "ForeignName": "COF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "COI",
+            "ForeignName": "COI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "COLX",
+            "ForeignName": "COLX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "COM_OLD",
+            "ForeignName": "COM_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "COMBI",
+            "ForeignName": "COMBI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CONST",
+            "ForeignName": "CONST-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CORONA_OLD",
+            "ForeignName": "CORONA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "COTD",
+            "ForeignName": "COTD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "COUPE",
+            "ForeignName": "COUPE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CPR",
+            "ForeignName": "CPR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CPR",
+            "ForeignName": "CPR-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CPR",
+            "ForeignName": "CPR-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CPU",
+            "ForeignName": "CPU-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CREB",
+            "ForeignName": "CREB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CREDIT",
+            "ForeignName": "CREDIT-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CREP",
+            "ForeignName": "CREP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CREX",
+            "ForeignName": "CREX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CREX",
+            "ForeignName": "CREX-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CREX",
+            "ForeignName": "CREX-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CREX",
+            "ForeignName": "CREX-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CREX",
+            "ForeignName": "CREX-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRK",
+            "ForeignName": "CRK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRO",
+            "ForeignName": "CRO-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRP",
+            "ForeignName": "CRP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRS",
+            "ForeignName": "CRS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRSTK",
+            "ForeignName": "CRSTK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRSTK",
+            "ForeignName": "CRSTK-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRSTK",
+            "ForeignName": "CRSTK-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRSX",
+            "ForeignName": "CRSX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRUB",
+            "ForeignName": "CRUB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRUB",
+            "ForeignName": "CRUB-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRUIZE",
+            "ForeignName": "CRUIZE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRW",
+            "ForeignName": "CRW-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CRYPT",
+            "ForeignName": "CRYPT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CSO",
+            "ForeignName": "CSO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CSPN_OLD",
+            "ForeignName": "CSPN_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CSPN",
+            "ForeignName": "CSPN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CSTL_OLD",
+            "ForeignName": "CSTL_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CSTL",
+            "ForeignName": "CSTL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CTD",
+            "ForeignName": "CTD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CTF",
+            "ForeignName": "CTF-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CTL",
+            "ForeignName": "CTL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CTN",
+            "ForeignName": "CTN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CTN",
+            "ForeignName": "CTN-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CTN",
+            "ForeignName": "CTN-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CTN",
+            "ForeignName": "CTN-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CUBIC",
+            "ForeignName": "CUBIC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CUSD",
+            "ForeignName": "CUSD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CUT",
+            "ForeignName": "CUT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CVC",
+            "ForeignName": "CVC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CVCC",
+            "ForeignName": "CVCC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CXC",
+            "ForeignName": "CXC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CYMT",
+            "ForeignName": "CYMT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "CYR",
+            "ForeignName": "CYR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DACH",
+            "ForeignName": "DACH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DACHX",
+            "ForeignName": "DACHX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DAI",
+            "ForeignName": "DAI-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DAM",
+            "ForeignName": "DAM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DAM",
+            "ForeignName": "DAM-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DAPS",
+            "ForeignName": "DAPS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DAPS",
+            "ForeignName": "DAPS-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DASH",
+            "ForeignName": "DASH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DASHD",
+            "ForeignName": "DASHD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DASHG",
+            "ForeignName": "DASHG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DATP",
+            "ForeignName": "DATP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DATP",
+            "ForeignName": "DATP-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DCASH",
+            "ForeignName": "DCASH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DCBL",
+            "ForeignName": "DCBL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DC",
+            "ForeignName": "DC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DCNTR",
+            "ForeignName": "DCNTR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DCTO",
+            "ForeignName": "DCTO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DCTO",
+            "ForeignName": "DCTO-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DCU",
+            "ForeignName": "DCU-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DDR",
+            "ForeignName": "DDR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DDRST",
+            "ForeignName": "DDRST-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DDRST",
+            "ForeignName": "DDRST-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DDRST",
+            "ForeignName": "DDRST-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DDRT",
+            "ForeignName": "DDRT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DDRT",
+            "ForeignName": "DDRT-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DDRT",
+            "ForeignName": "DDRT-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DEAL",
+            "ForeignName": "DEAL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DEALT",
+            "ForeignName": "DEALT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DEC",
+            "ForeignName": "DEC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DEFIT",
+            "ForeignName": "DEFIT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DEFT",
+            "ForeignName": "DEFT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DELIV",
+            "ForeignName": "DELIV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DELIZ",
+            "ForeignName": "DELIZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DERO",
+            "ForeignName": "DERO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DEURO",
+            "ForeignName": "DEURO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DEXR",
+            "ForeignName": "DEXR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DEXR",
+            "ForeignName": "DEXR-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DEXR",
+            "ForeignName": "DEXR-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DGB",
+            "ForeignName": "DGB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DGB",
+            "ForeignName": "DGB-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DIME",
+            "ForeignName": "DIME-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DINGO",
+            "ForeignName": "DINGO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DINGO",
+            "ForeignName": "DINGO-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DINT",
+            "ForeignName": "DINT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DIVC",
+            "ForeignName": "DIVC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DIVI",
+            "ForeignName": "DIVI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DLX",
+            "ForeignName": "DLX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DMB",
+            "ForeignName": "DMB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DMD",
+            "ForeignName": "DMD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DMDC",
+            "ForeignName": "DMDC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DMD",
+            "ForeignName": "DMD-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DMME_OLD",
+            "ForeignName": "DMME_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DMME",
+            "ForeignName": "DMME-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DMS",
+            "ForeignName": "DMS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DNE",
+            "ForeignName": "DNE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DOGE",
+            "ForeignName": "DOGE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DOGE",
+            "ForeignName": "DOGE-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DOGE",
+            "ForeignName": "DOGE-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DON",
+            "ForeignName": "DON-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DOOS",
+            "ForeignName": "DOOS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DOOS",
+            "ForeignName": "DOOS-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DRM",
+            "ForeignName": "DRM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DRM",
+            "ForeignName": "DRM-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DRS",
+            "ForeignName": "DRS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DRS",
+            "ForeignName": "DRS-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DRS",
+            "ForeignName": "DRS-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DRT",
+            "ForeignName": "DRT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DSC",
+            "ForeignName": "DSC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DSP",
+            "ForeignName": "DSP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DST",
+            "ForeignName": "DST-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DTD",
+            "ForeignName": "DTD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DTL",
+            "ForeignName": "DTL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DTMI",
+            "ForeignName": "DTMI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DUDGX_OLD",
+            "ForeignName": "DUDGX_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DUDGX",
+            "ForeignName": "DUDGX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "DYX",
+            "ForeignName": "DYX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ECA",
+            "ForeignName": "ECA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ECC",
+            "ForeignName": "ECC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ECOS",
+            "ForeignName": "ECOS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ECOS",
+            "ForeignName": "ECOS-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EDC_OLD",
+            "ForeignName": "EDC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EDCC",
+            "ForeignName": "EDCC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EDCC",
+            "ForeignName": "EDCC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EDCC",
+            "ForeignName": "EDCC-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EDUX",
+            "ForeignName": "EDUX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EGA",
+            "ForeignName": "EGA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EGG",
+            "ForeignName": "EGG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EJOB",
+            "ForeignName": "EJOB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EJOB",
+            "ForeignName": "EJOB-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ELI",
+            "ForeignName": "ELI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ELYA",
+            "ForeignName": "ELYA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EMC",
+            "ForeignName": "EMC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EMN",
+            "ForeignName": "EMN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EMN",
+            "ForeignName": "EMN-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EMRALS",
+            "ForeignName": "EMRALS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EMTV",
+            "ForeignName": "EMTV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EMTV",
+            "ForeignName": "EMTV-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EMTV",
+            "ForeignName": "EMTV-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ENG",
+            "ForeignName": "ENG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ENQ",
+            "ForeignName": "ENQ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ENQ",
+            "ForeignName": "ENQ-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ENQ",
+            "ForeignName": "ENQ-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ENQ",
+            "ForeignName": "ENQ-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ENRG",
+            "ForeignName": "ENRG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ENTRC",
+            "ForeignName": "ENTRC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ENTS",
+            "ForeignName": "ENTS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ENY",
+            "ForeignName": "ENY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EOS_TOKEN",
+            "ForeignName": "EOS_TOKEN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EOS",
+            "ForeignName": "EOS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EOS",
+            "ForeignName": "EOS-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EOS",
+            "ForeignName": "EOS-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EPG",
+            "ForeignName": "EPG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EPIC_OLD",
+            "ForeignName": "EPIC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EPIC",
+            "ForeignName": "EPIC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EPM_OLD",
+            "ForeignName": "EPM_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EPM",
+            "ForeignName": "EPM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EPS",
+            "ForeignName": "EPS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EPTK_OLD2",
+            "ForeignName": "EPTK_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EPTK_OLD",
+            "ForeignName": "EPTK_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ERC",
+            "ForeignName": "ERC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ERC",
+            "ForeignName": "ERC-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ERD",
+            "ForeignName": "ERD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ERD",
+            "ForeignName": "ERD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ERK_OLD",
+            "ForeignName": "ERK_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ERK_OLD",
+            "ForeignName": "ERK_OLD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ERK",
+            "ForeignName": "ERK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ERK",
+            "ForeignName": "ERK-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ERS",
+            "ForeignName": "ERS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ESBC",
+            "ForeignName": "ESBC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ESBC",
+            "ForeignName": "ESBC-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ESCE",
+            "ForeignName": "ESCE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ESH",
+            "ForeignName": "ESH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ESK",
+            "ForeignName": "ESK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ESM",
+            "ForeignName": "ESM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ESN",
+            "ForeignName": "ESN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ESN",
+            "ForeignName": "ESN-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ESN",
+            "ForeignName": "ESN-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ESTO",
+            "ForeignName": "ESTO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETC",
+            "ForeignName": "ETC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETC",
+            "ForeignName": "ETC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETHM_OLD",
+            "ForeignName": "ETHM_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETHM",
+            "ForeignName": "ETHM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH-PAX",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETHSC",
+            "ForeignName": "ETHSC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH-TUSD",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH-USDC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETM",
+            "ForeignName": "ETM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETM",
+            "ForeignName": "ETM-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETR",
+            "ForeignName": "ETR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ETRT",
+            "ForeignName": "ETRT-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EUNO",
+            "ForeignName": "EUNO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EURT",
+            "ForeignName": "EURT-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVEO",
+            "ForeignName": "EVEO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVEO",
+            "ForeignName": "EVEO-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVEO",
+            "ForeignName": "EVEO-JPY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVEO",
+            "ForeignName": "EVEO-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVEO",
+            "ForeignName": "EVEO-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVI_OLD",
+            "ForeignName": "EVI_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVI",
+            "ForeignName": "EVI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVOS",
+            "ForeignName": "EVOS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVR",
+            "ForeignName": "EVR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVR",
+            "ForeignName": "EVR-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVR",
+            "ForeignName": "EVR-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVR",
+            "ForeignName": "EVR-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EVR",
+            "ForeignName": "EVR-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EXISTV2",
+            "ForeignName": "EXISTV2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EXO_OLD",
+            "ForeignName": "EXO_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EXO",
+            "ForeignName": "EXO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EXPO",
+            "ForeignName": "EXPO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EXTN",
+            "ForeignName": "EXTN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EYCO",
+            "ForeignName": "EYCO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EZPAY_OLD",
+            "ForeignName": "EZPAY_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EZPAY",
+            "ForeignName": "EZPAY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "EZY",
+            "ForeignName": "EZY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "F4L8",
+            "ForeignName": "F4L8-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FAUCET",
+            "ForeignName": "FAUCET-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FAW",
+            "ForeignName": "FAW-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FBN_OLD2",
+            "ForeignName": "FBN_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FBN_OLD",
+            "ForeignName": "FBN_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FBN",
+            "ForeignName": "FBN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FCH",
+            "ForeignName": "FCH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FDR_OLD",
+            "ForeignName": "FDR_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FDR",
+            "ForeignName": "FDR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FEX",
+            "ForeignName": "FEX-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FIC",
+            "ForeignName": "FIC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FIC",
+            "ForeignName": "FIC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FIC",
+            "ForeignName": "FIC-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FJC",
+            "ForeignName": "FJC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLASH",
+            "ForeignName": "FLASH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLASH",
+            "ForeignName": "FLASH-CNY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLASH",
+            "ForeignName": "FLASH-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLASH",
+            "ForeignName": "FLASH-JPY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLASH",
+            "ForeignName": "FLASH-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLASH",
+            "ForeignName": "FLASH-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLK",
+            "ForeignName": "FLK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLOT",
+            "ForeignName": "FLOT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLOT",
+            "ForeignName": "FLOT-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLOT",
+            "ForeignName": "FLOT-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLS",
+            "ForeignName": "FLS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLS",
+            "ForeignName": "FLS-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FLX",
+            "ForeignName": "FLX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FNO",
+            "ForeignName": "FNO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FOLK",
+            "ForeignName": "FOLK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FORK",
+            "ForeignName": "FORK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FOS",
+            "ForeignName": "FOS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FOTC",
+            "ForeignName": "FOTC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FRC",
+            "ForeignName": "FRC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FREE",
+            "ForeignName": "FREE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FREE",
+            "ForeignName": "FREE-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FREE",
+            "ForeignName": "FREE-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FREE",
+            "ForeignName": "FREE-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FST",
+            "ForeignName": "FST-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FTC",
+            "ForeignName": "FTC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FTOKEN",
+            "ForeignName": "FTOKEN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FTON",
+            "ForeignName": "FTON-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FUNC",
+            "ForeignName": "FUNC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FUND",
+            "ForeignName": "FUND-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FUND",
+            "ForeignName": "FUND-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FURT",
+            "ForeignName": "FURT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FUTR",
+            "ForeignName": "FUTR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FUTX",
+            "ForeignName": "FUTX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FWY",
+            "ForeignName": "FWY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FWY",
+            "ForeignName": "FWY-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FXC",
+            "ForeignName": "FXC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FXN",
+            "ForeignName": "FXN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FXTC",
+            "ForeignName": "FXTC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FYD",
+            "ForeignName": "FYD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "FZCOIN",
+            "ForeignName": "FZCOIN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GAL",
+            "ForeignName": "GAL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GALI",
+            "ForeignName": "GALI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GAME_OLD",
+            "ForeignName": "GAME_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GAME",
+            "ForeignName": "GAME-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GAME",
+            "ForeignName": "GAME-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GAU",
+            "ForeignName": "GAU-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GCASH",
+            "ForeignName": "GCASH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GCC",
+            "ForeignName": "GCC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GCH",
+            "ForeignName": "GCH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GCN",
+            "ForeignName": "GCN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GENE",
+            "ForeignName": "GENE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GEX",
+            "ForeignName": "GEX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GFC",
+            "ForeignName": "GFC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GFNC",
+            "ForeignName": "GFNC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GFR",
+            "ForeignName": "GFR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GHOST",
+            "ForeignName": "GHOST-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GIC",
+            "ForeignName": "GIC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GICT",
+            "ForeignName": "GICT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GICT",
+            "ForeignName": "GICT-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GIVE",
+            "ForeignName": "GIVE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GLT_Delisted",
+            "ForeignName": "GLT_Delisted-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GLT",
+            "ForeignName": "GLT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GLYNO",
+            "ForeignName": "GLYNO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GM",
+            "ForeignName": "GM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GNC",
+            "ForeignName": "GNC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GNT",
+            "ForeignName": "GNT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GOAT",
+            "ForeignName": "GOAT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GOAT",
+            "ForeignName": "GOAT-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GOL",
+            "ForeignName": "GOL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GOLD",
+            "ForeignName": "GOLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GOLDR",
+            "ForeignName": "GOLDR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GOLDR",
+            "ForeignName": "GOLDR-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GOLDR",
+            "ForeignName": "GOLDR-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GOSS",
+            "ForeignName": "GOSS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GRLC",
+            "ForeignName": "GRLC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GRNC",
+            "ForeignName": "GRNC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GRNT",
+            "ForeignName": "GRNT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GRP",
+            "ForeignName": "GRP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GSR",
+            "ForeignName": "GSR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GTM",
+            "ForeignName": "GTM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GTO",
+            "ForeignName": "GTO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GUSD",
+            "ForeignName": "GUSD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GVC",
+            "ForeignName": "GVC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GXT",
+            "ForeignName": "GXT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GXT",
+            "ForeignName": "GXT-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GXT",
+            "ForeignName": "GXT-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GXX",
+            "ForeignName": "GXX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "GZRO",
+            "ForeignName": "GZRO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HALV_OLD",
+            "ForeignName": "HALV_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HALV",
+            "ForeignName": "HALV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HAN",
+            "ForeignName": "HAN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HAN",
+            "ForeignName": "HAN-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HARON",
+            "ForeignName": "HARON-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HARON",
+            "ForeignName": "HARON-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HASH",
+            "ForeignName": "HASH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HBX",
+            "ForeignName": "HBX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HC8",
+            "ForeignName": "HC8-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HCA",
+            "ForeignName": "HCA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HDN",
+            "ForeignName": "HDN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HDN",
+            "ForeignName": "HDN-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HEMP",
+            "ForeignName": "HEMP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HGH",
+            "ForeignName": "HGH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HIGHT",
+            "ForeignName": "HIGHT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HIZ",
+            "ForeignName": "HIZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HLIX",
+            "ForeignName": "HLIX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HLMN",
+            "ForeignName": "HLMN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HLO",
+            "ForeignName": "HLO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HLP",
+            "ForeignName": "HLP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HME",
+            "ForeignName": "HME-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HMR",
+            "ForeignName": "HMR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HMR",
+            "ForeignName": "HMR-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HMR",
+            "ForeignName": "HMR-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HNDC",
+            "ForeignName": "HNDC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HOMI",
+            "ForeignName": "HOMI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HOT",
+            "ForeignName": "HOT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HTML",
+            "ForeignName": "HTML-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HWC",
+            "ForeignName": "HWC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "HWI",
+            "ForeignName": "HWI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "I9C",
+            "ForeignName": "I9C-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "I9X",
+            "ForeignName": "I9X-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IAN",
+            "ForeignName": "IAN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ICC",
+            "ForeignName": "ICC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ICH_OLD",
+            "ForeignName": "ICH_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ICH",
+            "ForeignName": "ICH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ICR",
+            "ForeignName": "ICR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ICR",
+            "ForeignName": "ICR-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ICX",
+            "ForeignName": "ICX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IDG",
+            "ForeignName": "IDG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IDX",
+            "ForeignName": "IDX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IFC",
+            "ForeignName": "IFC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IFX24",
+            "ForeignName": "IFX24-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ILC",
+            "ForeignName": "ILC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ILC",
+            "ForeignName": "ILC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ILC",
+            "ForeignName": "ILC-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IMG_OLD",
+            "ForeignName": "IMG_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IMG",
+            "ForeignName": "IMG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IMGC",
+            "ForeignName": "IMGC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IMPL",
+            "ForeignName": "IMPL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INFS",
+            "ForeignName": "INFS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INN_OLD",
+            "ForeignName": "INN_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INNBC_OLD",
+            "ForeignName": "INNBC_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INNBC_OLD",
+            "ForeignName": "INNBC_OLD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INNBC",
+            "ForeignName": "INNBC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INNBCL_OLD",
+            "ForeignName": "INNBCL_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INNBCL_OLD",
+            "ForeignName": "INNBCL_OLD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INNBCL",
+            "ForeignName": "INNBCL-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INNBCL",
+            "ForeignName": "INNBCL-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INNBC",
+            "ForeignName": "INNBC-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INNBC",
+            "ForeignName": "INNBC-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INN",
+            "ForeignName": "INN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INT",
+            "ForeignName": "INT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "INTU",
+            "ForeignName": "INTU-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ION",
+            "ForeignName": "ION-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IOP",
+            "ForeignName": "IOP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IOP",
+            "ForeignName": "IOP-CNY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IOP",
+            "ForeignName": "IOP-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IOP",
+            "ForeignName": "IOP-JPY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IOP",
+            "ForeignName": "IOP-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IOP",
+            "ForeignName": "IOP-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IOTS",
+            "ForeignName": "IOTS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IPR",
+            "ForeignName": "IPR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IPS",
+            "ForeignName": "IPS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IQ",
+            "ForeignName": "IQ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IRD",
+            "ForeignName": "IRD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ITL",
+            "ForeignName": "ITL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IUT",
+            "ForeignName": "IUT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IUT",
+            "ForeignName": "IUT-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IUT",
+            "ForeignName": "IUT-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IZER",
+            "ForeignName": "IZER-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "IZZ",
+            "ForeignName": "IZZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JDC_OLD",
+            "ForeignName": "JDC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JDC_OLD",
+            "ForeignName": "JDC_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JDC_OLD",
+            "ForeignName": "JDC_OLD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JDC",
+            "ForeignName": "JDC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JDC",
+            "ForeignName": "JDC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JDC",
+            "ForeignName": "JDC-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JLC",
+            "ForeignName": "JLC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JMC",
+            "ForeignName": "JMC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JMC",
+            "ForeignName": "JMC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JOOPS",
+            "ForeignName": "JOOPS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JOOS",
+            "ForeignName": "JOOS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JOY",
+            "ForeignName": "JOY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JUMP",
+            "ForeignName": "JUMP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JWL",
+            "ForeignName": "JWL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "JWL",
+            "ForeignName": "JWL-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "K2X",
+            "ForeignName": "K2X-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KALI",
+            "ForeignName": "KALI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KEK",
+            "ForeignName": "KEK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KEY",
+            "ForeignName": "KEY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KFX",
+            "ForeignName": "KFX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KGS",
+            "ForeignName": "KGS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KGS",
+            "ForeignName": "KGS-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KICK",
+            "ForeignName": "KICK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KICK",
+            "ForeignName": "KICK-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KICK",
+            "ForeignName": "KICK-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KING",
+            "ForeignName": "KING-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KKC",
+            "ForeignName": "KKC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KLKS",
+            "ForeignName": "KLKS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KLO",
+            "ForeignName": "KLO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KMD",
+            "ForeignName": "KMD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KNT",
+            "ForeignName": "KNT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KNT",
+            "ForeignName": "KNT-CNY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KNT",
+            "ForeignName": "KNT-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KNT",
+            "ForeignName": "KNT-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KNT",
+            "ForeignName": "KNT-JPY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KNT",
+            "ForeignName": "KNT-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KNT",
+            "ForeignName": "KNT-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KOD",
+            "ForeignName": "KOD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KOIN",
+            "ForeignName": "KOIN-BUSD",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KOIN",
+            "ForeignName": "KOIN-PAX",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KOIN",
+            "ForeignName": "KOIN-USDC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KOKU",
+            "ForeignName": "KOKU-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KOLIN",
+            "ForeignName": "KOLIN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KONJ_OLD",
+            "ForeignName": "KONJ_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KONJ_OLD",
+            "ForeignName": "KONJ_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KONJ",
+            "ForeignName": "KONJ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KONJ",
+            "ForeignName": "KONJ-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KOTO",
+            "ForeignName": "KOTO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KPC",
+            "ForeignName": "KPC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KPX",
+            "ForeignName": "KPX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KRB",
+            "ForeignName": "KRB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KRC",
+            "ForeignName": "KRC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KREDS",
+            "ForeignName": "KREDS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KTS_OLD",
+            "ForeignName": "KTS_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KTS",
+            "ForeignName": "KTS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KTV",
+            "ForeignName": "KTV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KTY",
+            "ForeignName": "KTY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KUB",
+            "ForeignName": "KUB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KUBO_OLD",
+            "ForeignName": "KUBO_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KUBO_OLD",
+            "ForeignName": "KUBO_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KUBO_OLD",
+            "ForeignName": "KUBO_OLD-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KUBO",
+            "ForeignName": "KUBO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KUBO",
+            "ForeignName": "KUBO-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KUBO",
+            "ForeignName": "KUBO-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KYDC",
+            "ForeignName": "KYDC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KYF",
+            "ForeignName": "KYF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KYF",
+            "ForeignName": "KYF-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "KYF",
+            "ForeignName": "KYF-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LABX",
+            "ForeignName": "LABX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LAD",
+            "ForeignName": "LAD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LAIKA",
+            "ForeignName": "LAIKA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LBOT",
+            "ForeignName": "LBOT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LC",
+            "ForeignName": "LC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LCP",
+            "ForeignName": "LCP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LDC",
+            "ForeignName": "LDC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LDR",
+            "ForeignName": "LDR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LIBFX",
+            "ForeignName": "LIBFX-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LIBREF",
+            "ForeignName": "LIBREF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LIBREF",
+            "ForeignName": "LIBREF-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LILI",
+            "ForeignName": "LILI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LINC",
+            "ForeignName": "LINC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LINK",
+            "ForeignName": "LINK-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LIZ",
+            "ForeignName": "LIZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LIZ",
+            "ForeignName": "LIZ-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LKR",
+            "ForeignName": "LKR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LMCH",
+            "ForeignName": "LMCH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LMCH",
+            "ForeignName": "LMCH-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LMCH",
+            "ForeignName": "LMCH-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LNO",
+            "ForeignName": "LNO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LNO",
+            "ForeignName": "LNO-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LNOT",
+            "ForeignName": "LNOT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LNO",
+            "ForeignName": "LNO-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LOC",
+            "ForeignName": "LOC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LOG",
+            "ForeignName": "LOG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LPC",
+            "ForeignName": "LPC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LSR",
+            "ForeignName": "LSR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LSV",
+            "ForeignName": "LSV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LTCB",
+            "ForeignName": "LTCB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LTC",
+            "ForeignName": "LTC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LTC",
+            "ForeignName": "LTC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LTC",
+            "ForeignName": "LTC-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LTFN",
+            "ForeignName": "LTFN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LUK",
+            "ForeignName": "LUK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LVT",
+            "ForeignName": "LVT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "LYTX",
+            "ForeignName": "LYTX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MAC",
+            "ForeignName": "MAC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MACC",
+            "ForeignName": "MACC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MAG",
+            "ForeignName": "MAG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MAGN",
+            "ForeignName": "MAGN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MAG",
+            "ForeignName": "MAG-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MALW",
+            "ForeignName": "MALW-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MALW",
+            "ForeignName": "MALW-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MALW",
+            "ForeignName": "MALW-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MAR",
+            "ForeignName": "MAR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MARC",
+            "ForeignName": "MARC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MAR",
+            "ForeignName": "MAR-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MBGL",
+            "ForeignName": "MBGL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MCO",
+            "ForeignName": "MCO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MCPC",
+            "ForeignName": "MCPC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MDAO",
+            "ForeignName": "MDAO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MDC",
+            "ForeignName": "MDC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MDEX",
+            "ForeignName": "MDEX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MDL",
+            "ForeignName": "MDL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MDTK",
+            "ForeignName": "MDTK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MDZ",
+            "ForeignName": "MDZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MEC",
+            "ForeignName": "MEC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MEC",
+            "ForeignName": "MEC-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MEK_OLD",
+            "ForeignName": "MEK_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MEK",
+            "ForeignName": "MEK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MEK",
+            "ForeignName": "MEK-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MERI",
+            "ForeignName": "MERI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "META",
+            "ForeignName": "META-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "METC",
+            "ForeignName": "METC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "METRO_OLD",
+            "ForeignName": "METRO_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MFC_OLD",
+            "ForeignName": "MFC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MFC",
+            "ForeignName": "MFC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MFIT",
+            "ForeignName": "MFIT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MGN",
+            "ForeignName": "MGN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MIAMI",
+            "ForeignName": "MIAMI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MIC3_OLD",
+            "ForeignName": "MIC3_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MIC3_OLD",
+            "ForeignName": "MIC3_OLD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MIC3",
+            "ForeignName": "MIC3-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MICRO",
+            "ForeignName": "MICRO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MICRO",
+            "ForeignName": "MICRO-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MIDAS",
+            "ForeignName": "MIDAS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MINC",
+            "ForeignName": "MINC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MK",
+            "ForeignName": "MK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MKT",
+            "ForeignName": "MKT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MLM",
+            "ForeignName": "MLM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MLM",
+            "ForeignName": "MLM-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MLM",
+            "ForeignName": "MLM-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MMO",
+            "ForeignName": "MMO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MMO",
+            "ForeignName": "MMO-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MNEX",
+            "ForeignName": "MNEX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MNP",
+            "ForeignName": "MNP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MNTIS",
+            "ForeignName": "MNTIS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MOC",
+            "ForeignName": "MOC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MODIC",
+            "ForeignName": "MODIC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MODX",
+            "ForeignName": "MODX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MOG",
+            "ForeignName": "MOG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MONA",
+            "ForeignName": "MONA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MONK",
+            "ForeignName": "MONK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MOUSE",
+            "ForeignName": "MOUSE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MOVE",
+            "ForeignName": "MOVE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MOVE",
+            "ForeignName": "MOVE-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MPCN",
+            "ForeignName": "MPCN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MRC",
+            "ForeignName": "MRC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MRI",
+            "ForeignName": "MRI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MRNT",
+            "ForeignName": "MRNT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MRV",
+            "ForeignName": "MRV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MRX_OLD",
+            "ForeignName": "MRX_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MRX",
+            "ForeignName": "MRX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MSR",
+            "ForeignName": "MSR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MSTC",
+            "ForeignName": "MSTC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MTE",
+            "ForeignName": "MTE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MTLC",
+            "ForeignName": "MTLC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MTNS",
+            "ForeignName": "MTNS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MTNS",
+            "ForeignName": "MTNS-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MTNS",
+            "ForeignName": "MTNS-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MTS",
+            "ForeignName": "MTS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MUSD",
+            "ForeignName": "MUSD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MUSD",
+            "ForeignName": "MUSD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MUSD",
+            "ForeignName": "MUSD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MUX",
+            "ForeignName": "MUX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MVG_OLD",
+            "ForeignName": "MVG_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MVG_OLD",
+            "ForeignName": "MVG_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MVG_OLD",
+            "ForeignName": "MVG_OLD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MW",
+            "ForeignName": "MW-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MXT",
+            "ForeignName": "MXT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MYFI_OLD",
+            "ForeignName": "MYFI_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MYFI",
+            "ForeignName": "MYFI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "MYFI",
+            "ForeignName": "MYFI-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NAV",
+            "ForeignName": "NAV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NBR",
+            "ForeignName": "NBR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NBX",
+            "ForeignName": "NBX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NBX",
+            "ForeignName": "NBX-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NBX",
+            "ForeignName": "NBX-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NCASH",
+            "ForeignName": "NCASH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NCN",
+            "ForeignName": "NCN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NCP",
+            "ForeignName": "NCP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NDB",
+            "ForeignName": "NDB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NDT",
+            "ForeignName": "NDT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NEET",
+            "ForeignName": "NEET-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NEOS",
+            "ForeignName": "NEOS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NEXT",
+            "ForeignName": "NEXT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NIHL",
+            "ForeignName": "NIHL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NIL",
+            "ForeignName": "NIL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NIL",
+            "ForeignName": "NIL-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NMN",
+            "ForeignName": "NMN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NPAY",
+            "ForeignName": "NPAY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NPC",
+            "ForeignName": "NPC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NPC",
+            "ForeignName": "NPC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NPC",
+            "ForeignName": "NPC-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NSC",
+            "ForeignName": "NSC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NSD",
+            "ForeignName": "NSD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NSDC",
+            "ForeignName": "NSDC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NSDC",
+            "ForeignName": "NSDC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NSD",
+            "ForeignName": "NSD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NST",
+            "ForeignName": "NST-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NST",
+            "ForeignName": "NST-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NST",
+            "ForeignName": "NST-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NTBK",
+            "ForeignName": "NTBK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NTK",
+            "ForeignName": "NTK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NUX",
+            "ForeignName": "NUX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NWO",
+            "ForeignName": "NWO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NXB",
+            "ForeignName": "NXB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NYB",
+            "ForeignName": "NYB-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NYC",
+            "ForeignName": "NYC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NYE",
+            "ForeignName": "NYE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NYE",
+            "ForeignName": "NYE-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NYEX",
+            "ForeignName": "NYEX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "NZL",
+            "ForeignName": "NZL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OBSR",
+            "ForeignName": "OBSR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OBX",
+            "ForeignName": "OBX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OCUL",
+            "ForeignName": "OCUL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ODEX",
+            "ForeignName": "ODEX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ODEX",
+            "ForeignName": "ODEX-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OES",
+            "ForeignName": "OES-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OK",
+            "ForeignName": "OK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OK",
+            "ForeignName": "OK-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OK",
+            "ForeignName": "OK-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OLBC",
+            "ForeignName": "OLBC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OLGA",
+            "ForeignName": "OLGA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OMEGA",
+            "ForeignName": "OMEGA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OMG",
+            "ForeignName": "OMG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ONE",
+            "ForeignName": "ONE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ONEPAY",
+            "ForeignName": "ONEPAY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ONION",
+            "ForeignName": "ONION-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ONION",
+            "ForeignName": "ONION-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ONION",
+            "ForeignName": "ONION-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ONION",
+            "ForeignName": "ONION-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ONLEXPA",
+            "ForeignName": "ONLEXPA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OPCX",
+            "ForeignName": "OPCX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OPLC",
+            "ForeignName": "OPLC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ORKIT",
+            "ForeignName": "ORKIT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ORO",
+            "ForeignName": "ORO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OTO",
+            "ForeignName": "OTO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OTO",
+            "ForeignName": "OTO-USDC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OUM",
+            "ForeignName": "OUM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OWC_OLD",
+            "ForeignName": "OWC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OWC_OLD",
+            "ForeignName": "OWC_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OWC",
+            "ForeignName": "OWC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OWC",
+            "ForeignName": "OWC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OWN",
+            "ForeignName": "OWN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OWO_OLD",
+            "ForeignName": "OWO_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OWO",
+            "ForeignName": "OWO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "OX1",
+            "ForeignName": "OX1-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "P2P",
+            "ForeignName": "P2P-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PAPEL",
+            "ForeignName": "PAPEL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PAX",
+            "ForeignName": "PAX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PAXEX_OLD",
+            "ForeignName": "PAXEX_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PAXEX",
+            "ForeignName": "PAXEX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PAX",
+            "ForeignName": "PAX-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PAX",
+            "ForeignName": "PAX-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PAYTOMAT",
+            "ForeignName": "PAYTOMAT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PCR",
+            "ForeignName": "PCR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PCT",
+            "ForeignName": "PCT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PDG",
+            "ForeignName": "PDG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PENG",
+            "ForeignName": "PENG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PEO",
+            "ForeignName": "PEO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PEPS",
+            "ForeignName": "PEPS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PHL_OLD2",
+            "ForeignName": "PHL_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PHL_OLD",
+            "ForeignName": "PHL_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PHL",
+            "ForeignName": "PHL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PHN",
+            "ForeignName": "PHN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PHN",
+            "ForeignName": "PHN-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PHN",
+            "ForeignName": "PHN-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PHON",
+            "ForeignName": "PHON-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PHR",
+            "ForeignName": "PHR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PIPL",
+            "ForeignName": "PIPL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PIRATE",
+            "ForeignName": "PIRATE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PIVX",
+            "ForeignName": "PIVX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PLAT",
+            "ForeignName": "PLAT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PLF",
+            "ForeignName": "PLF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PLF",
+            "ForeignName": "PLF-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PLF",
+            "ForeignName": "PLF-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PLURA",
+            "ForeignName": "PLURA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PLURA",
+            "ForeignName": "PLURA-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PLURA",
+            "ForeignName": "PLURA-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PNX",
+            "ForeignName": "PNX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PNY_OLD",
+            "ForeignName": "PNY_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PNY",
+            "ForeignName": "PNY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "POD",
+            "ForeignName": "POD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "POIX",
+            "ForeignName": "POIX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "POLIS",
+            "ForeignName": "POLIS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "POMAC",
+            "ForeignName": "POMAC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "POP",
+            "ForeignName": "POP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "POP",
+            "ForeignName": "POP-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "POP",
+            "ForeignName": "POP-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "POP",
+            "ForeignName": "POP-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "POSI",
+            "ForeignName": "POSI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "POSQ",
+            "ForeignName": "POSQ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "POSS",
+            "ForeignName": "POSS-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PPD",
+            "ForeignName": "PPD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRC",
+            "ForeignName": "PRC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRC",
+            "ForeignName": "PRC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRE",
+            "ForeignName": "PRE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRIV",
+            "ForeignName": "PRIV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRIV",
+            "ForeignName": "PRIV-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRIV",
+            "ForeignName": "PRIV-JPY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRIV",
+            "ForeignName": "PRIV-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRJ",
+            "ForeignName": "PRJ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRJECT",
+            "ForeignName": "PRJECT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRN",
+            "ForeignName": "PRN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRON",
+            "ForeignName": "PRON-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PROUD",
+            "ForeignName": "PROUD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PROUD",
+            "ForeignName": "PROUD-CNY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PROUD",
+            "ForeignName": "PROUD-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PROUD",
+            "ForeignName": "PROUD-JPY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PROUD",
+            "ForeignName": "PROUD-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PROUD",
+            "ForeignName": "PROUD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PROVE",
+            "ForeignName": "PROVE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PRX",
+            "ForeignName": "PRX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PSC_OLD",
+            "ForeignName": "PSC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PSTAR",
+            "ForeignName": "PSTAR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PUMP_OLD",
+            "ForeignName": "PUMP_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PUMP",
+            "ForeignName": "PUMP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PUT_OLD",
+            "ForeignName": "PUT_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PUT",
+            "ForeignName": "PUT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PWRB",
+            "ForeignName": "PWRB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PWR",
+            "ForeignName": "PWR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "PYRK",
+            "ForeignName": "PYRK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "Q8E20",
+            "ForeignName": "Q8E20-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "Q8E20",
+            "ForeignName": "Q8E20-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "Q8E20",
+            "ForeignName": "Q8E20-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "Q8E",
+            "ForeignName": "Q8E-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "QBIT",
+            "ForeignName": "QBIT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "QBS",
+            "ForeignName": "QBS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "QNO_OLD",
+            "ForeignName": "QNO_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "QNO",
+            "ForeignName": "QNO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "QPY",
+            "ForeignName": "QPY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "QTUM",
+            "ForeignName": "QTUM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "QUB",
+            "ForeignName": "QUB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "QUOT",
+            "ForeignName": "QUOT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "QWC",
+            "ForeignName": "QWC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "QXAN",
+            "ForeignName": "QXAN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RAGNA",
+            "ForeignName": "RAGNA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RAL",
+            "ForeignName": "RAL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RAL",
+            "ForeignName": "RAL-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RBC",
+            "ForeignName": "RBC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RC20",
+            "ForeignName": "RC20-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RCNUSA",
+            "ForeignName": "RCNUSA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RCSN",
+            "ForeignName": "RCSN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RD",
+            "ForeignName": "RD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RDC",
+            "ForeignName": "RDC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RDCT",
+            "ForeignName": "RDCT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RDD",
+            "ForeignName": "RDD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "REAK",
+            "ForeignName": "REAK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "REEX_OLD2",
+            "ForeignName": "REEX_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "REEX_OLD",
+            "ForeignName": "REEX_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "REEX",
+            "ForeignName": "REEX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RENTOO_OLD",
+            "ForeignName": "RENTOO_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RENTOO",
+            "ForeignName": "RENTOO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "REP_OLD",
+            "ForeignName": "REP_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "REP",
+            "ForeignName": "REP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RESQ_OLD",
+            "ForeignName": "RESQ_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RESQ",
+            "ForeignName": "RESQ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "REVU_OLD",
+            "ForeignName": "REVU_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "REVU",
+            "ForeignName": "REVU-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "REV",
+            "ForeignName": "REV-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RGS",
+            "ForeignName": "RGS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RICK",
+            "ForeignName": "RICK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RIL",
+            "ForeignName": "RIL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RKN",
+            "ForeignName": "RKN-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RKT",
+            "ForeignName": "RKT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RLD_TOKEN",
+            "ForeignName": "RLD_TOKEN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ROCO",
+            "ForeignName": "ROCO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RPD_OLD",
+            "ForeignName": "RPD_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RPD",
+            "ForeignName": "RPD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RPG",
+            "ForeignName": "RPG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RPI",
+            "ForeignName": "RPI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RSIN",
+            "ForeignName": "RSIN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RSIN",
+            "ForeignName": "RSIN-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RSP",
+            "ForeignName": "RSP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RUP",
+            "ForeignName": "RUP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RUP",
+            "ForeignName": "RUP-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RVIEW",
+            "ForeignName": "RVIEW-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RYO",
+            "ForeignName": "RYO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RYO",
+            "ForeignName": "RYO-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RYO",
+            "ForeignName": "RYO-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "RYO",
+            "ForeignName": "RYO-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SAFE",
+            "ForeignName": "SAFE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SAKE",
+            "ForeignName": "SAKE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SAP",
+            "ForeignName": "SAP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SAPP",
+            "ForeignName": "SAPP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SATC",
+            "ForeignName": "SATC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SBE",
+            "ForeignName": "SBE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SBE",
+            "ForeignName": "SBE-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SBE",
+            "ForeignName": "SBE-TUSD",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SBTC",
+            "ForeignName": "SBTC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCAP_OLD",
+            "ForeignName": "SCAP_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCAP",
+            "ForeignName": "SCAP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCC_OLD",
+            "ForeignName": "SCC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCC",
+            "ForeignName": "SCC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCH",
+            "ForeignName": "SCH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCH",
+            "ForeignName": "SCH-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCH",
+            "ForeignName": "SCH-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCH",
+            "ForeignName": "SCH-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCRIBE",
+            "ForeignName": "SCRIBE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCRIV",
+            "ForeignName": "SCRIV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCS",
+            "ForeignName": "SCS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCS",
+            "ForeignName": "SCS-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SCS",
+            "ForeignName": "SCS-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SDD",
+            "ForeignName": "SDD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SDGO",
+            "ForeignName": "SDGO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SDGO",
+            "ForeignName": "SDGO-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SDY",
+            "ForeignName": "SDY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SECI",
+            "ForeignName": "SECI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SEKO",
+            "ForeignName": "SEKO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SERA",
+            "ForeignName": "SERA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SFD",
+            "ForeignName": "SFD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SHARK",
+            "ForeignName": "SHARK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SHND_OLD",
+            "ForeignName": "SHND_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SHND_OLD",
+            "ForeignName": "SHND_OLD-JPY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SHND",
+            "ForeignName": "SHND-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SHND",
+            "ForeignName": "SHND-JPY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SHOP",
+            "ForeignName": "SHOP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SHPO",
+            "ForeignName": "SHPO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SHUT",
+            "ForeignName": "SHUT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SICA",
+            "ForeignName": "SICA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SIERRA",
+            "ForeignName": "SIERRA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SIF",
+            "ForeignName": "SIF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SIN",
+            "ForeignName": "SIN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SIN",
+            "ForeignName": "SIN-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SIN",
+            "ForeignName": "SIN-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SINS",
+            "ForeignName": "SINS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SKN",
+            "ForeignName": "SKN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SLD",
+            "ForeignName": "SLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SLRC_old",
+            "ForeignName": "SLRC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SLT",
+            "ForeignName": "SLT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SNL",
+            "ForeignName": "SNL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SNL",
+            "ForeignName": "SNL-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SNL",
+            "ForeignName": "SNL-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SNO",
+            "ForeignName": "SNO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SNT",
+            "ForeignName": "SNT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SONO",
+            "ForeignName": "SONO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SOV",
+            "ForeignName": "SOV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SOVE",
+            "ForeignName": "SOVE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SPAC",
+            "ForeignName": "SPAC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SPDR",
+            "ForeignName": "SPDR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SPE",
+            "ForeignName": "SPE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SPEED",
+            "ForeignName": "SPEED-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SPH",
+            "ForeignName": "SPH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SPH",
+            "ForeignName": "SPH-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SPH",
+            "ForeignName": "SPH-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SPRTZ",
+            "ForeignName": "SPRTZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SPT",
+            "ForeignName": "SPT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SQR",
+            "ForeignName": "SQR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SRK",
+            "ForeignName": "SRK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SSO",
+            "ForeignName": "SSO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SSS",
+            "ForeignName": "SSS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SSX_OLD",
+            "ForeignName": "SSX_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SSX",
+            "ForeignName": "SSX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STABL",
+            "ForeignName": "STABL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STAK",
+            "ForeignName": "STAK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STAK",
+            "ForeignName": "STAK-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STE",
+            "ForeignName": "STE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STEEP",
+            "ForeignName": "STEEP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STG",
+            "ForeignName": "STG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STL",
+            "ForeignName": "STL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STOC",
+            "ForeignName": "STOC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STONE",
+            "ForeignName": "STONE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STPX",
+            "ForeignName": "STPX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STRAT",
+            "ForeignName": "STRAT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STR",
+            "ForeignName": "STR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STREAM",
+            "ForeignName": "STREAM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STRMS",
+            "ForeignName": "STRMS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STRS",
+            "ForeignName": "STRS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STT",
+            "ForeignName": "STT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "STYL",
+            "ForeignName": "STYL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SUBX_OLD2",
+            "ForeignName": "SUBX_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SUBX_OLD",
+            "ForeignName": "SUBX_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SUBX2_OLD",
+            "ForeignName": "SUBX2_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SUN",
+            "ForeignName": "SUN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SUPER",
+            "ForeignName": "SUPER-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SURE",
+            "ForeignName": "SURE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SURE",
+            "ForeignName": "SURE-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SURE",
+            "ForeignName": "SURE-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SVR",
+            "ForeignName": "SVR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SVR",
+            "ForeignName": "SVR-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SVR",
+            "ForeignName": "SVR-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SWIFT_OLD",
+            "ForeignName": "SWIFT_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SWIFT",
+            "ForeignName": "SWIFT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SWIPP",
+            "ForeignName": "SWIPP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SWZ",
+            "ForeignName": "SWZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SXDT",
+            "ForeignName": "SXDT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SXUT",
+            "ForeignName": "SXUT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "SYZ",
+            "ForeignName": "SYZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TAVITT",
+            "ForeignName": "TAVITT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TBG",
+            "ForeignName": "TBG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TCH_OLD",
+            "ForeignName": "TCH_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TCH",
+            "ForeignName": "TCH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TCHTRX",
+            "ForeignName": "TCHTRX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TCP",
+            "ForeignName": "TCP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TCP",
+            "ForeignName": "TCP-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TDP",
+            "ForeignName": "TDP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TDPS",
+            "ForeignName": "TDPS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TELFX",
+            "ForeignName": "TELFX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TELFX",
+            "ForeignName": "TELFX-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TELOS",
+            "ForeignName": "TELOS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TELOS",
+            "ForeignName": "TELOS-CNY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TELOS",
+            "ForeignName": "TELOS-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TELOS",
+            "ForeignName": "TELOS-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TELOS",
+            "ForeignName": "TELOS-JPY",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TELOS",
+            "ForeignName": "TELOS-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TELOS",
+            "ForeignName": "TELOS-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TEX",
+            "ForeignName": "TEX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TEX",
+            "ForeignName": "TEX-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TEX",
+            "ForeignName": "TEX-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TFC",
+            "ForeignName": "TFC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TGI",
+            "ForeignName": "TGI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TGI",
+            "ForeignName": "TGI-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TGI",
+            "ForeignName": "TGI-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TGN_OLD",
+            "ForeignName": "TGN_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TGN",
+            "ForeignName": "TGN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THE_OLD",
+            "ForeignName": "THE_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THETA",
+            "ForeignName": "THETA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THEX",
+            "ForeignName": "THEX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THO",
+            "ForeignName": "THO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THOR",
+            "ForeignName": "THOR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THR_OLD",
+            "ForeignName": "THR_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THR_OLD",
+            "ForeignName": "THR_OLD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THR",
+            "ForeignName": "THR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THR",
+            "ForeignName": "THR-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THX_OLD2",
+            "ForeignName": "THX_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THX_OLD",
+            "ForeignName": "THX_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "THX",
+            "ForeignName": "THX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TICK",
+            "ForeignName": "TICK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TIGC",
+            "ForeignName": "TIGC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TIX",
+            "ForeignName": "TIX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TKM20",
+            "ForeignName": "TKM20-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TKM",
+            "ForeignName": "TKM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TKP_OLD",
+            "ForeignName": "TKP_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TKP",
+            "ForeignName": "TKP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TKTS",
+            "ForeignName": "TKTS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TKTS",
+            "ForeignName": "TKTS-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TLC",
+            "ForeignName": "TLC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TLC",
+            "ForeignName": "TLC-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TLR_OLD",
+            "ForeignName": "TLR_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TLR",
+            "ForeignName": "TLR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TMC",
+            "ForeignName": "TMC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TNC_OLD",
+            "ForeignName": "TNC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TNC_OLD",
+            "ForeignName": "TNC_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TNC_OLD",
+            "ForeignName": "TNC_OLD-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TNC",
+            "ForeignName": "TNC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TNC",
+            "ForeignName": "TNC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TNC",
+            "ForeignName": "TNC-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TNET",
+            "ForeignName": "TNET-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TNJ",
+            "ForeignName": "TNJ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TNR",
+            "ForeignName": "TNR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TOA",
+            "ForeignName": "TOA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TOK",
+            "ForeignName": "TOK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TOOR",
+            "ForeignName": "TOOR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TOUR",
+            "ForeignName": "TOUR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TPC",
+            "ForeignName": "TPC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TPT",
+            "ForeignName": "TPT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TRAID",
+            "ForeignName": "TRAID-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TRCN",
+            "ForeignName": "TRCN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TREX_OLD",
+            "ForeignName": "TREX_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TREX",
+            "ForeignName": "TREX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TRIT",
+            "ForeignName": "TRIT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TRND",
+            "ForeignName": "TRND-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TRNS",
+            "ForeignName": "TRNS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TROY",
+            "ForeignName": "TROY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TRTT",
+            "ForeignName": "TRTT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TRX_TOKEN",
+            "ForeignName": "TRX_TOKEN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TRX",
+            "ForeignName": "TRX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TRX",
+            "ForeignName": "TRX-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TTC_OLD",
+            "ForeignName": "TTC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TTN_OLD",
+            "ForeignName": "TTN_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TTN",
+            "ForeignName": "TTN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TTU",
+            "ForeignName": "TTU-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TUBE",
+            "ForeignName": "TUBE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TUSD",
+            "ForeignName": "TUSD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TUSD",
+            "ForeignName": "TUSD-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TUX",
+            "ForeignName": "TUX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TVS",
+            "ForeignName": "TVS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TYC",
+            "ForeignName": "TYC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TYC",
+            "ForeignName": "TYC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TYC",
+            "ForeignName": "TYC-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TYC",
+            "ForeignName": "TYC-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TYM",
+            "ForeignName": "TYM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "TZC",
+            "ForeignName": "TZC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UBL",
+            "ForeignName": "UBL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UCA",
+            "ForeignName": "UCA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UCH",
+            "ForeignName": "UCH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UDSH",
+            "ForeignName": "UDSH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UEC",
+            "ForeignName": "UEC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UGD",
+            "ForeignName": "UGD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UKC",
+            "ForeignName": "UKC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UKC",
+            "ForeignName": "UKC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UKEY",
+            "ForeignName": "UKEY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UKRA",
+            "ForeignName": "UKRA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ULG",
+            "ForeignName": "ULG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UMC",
+            "ForeignName": "UMC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UNI",
+            "ForeignName": "UNI-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UNIV",
+            "ForeignName": "UNIV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UPC",
+            "ForeignName": "UPC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "URALS",
+            "ForeignName": "URALS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "URALS",
+            "ForeignName": "URALS-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "URALS",
+            "ForeignName": "URALS-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "USDC",
+            "ForeignName": "USDC-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "USDC",
+            "ForeignName": "USDC-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "USDC",
+            "ForeignName": "USDC-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "USDS",
+            "ForeignName": "USDS-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "USDT",
+            "ForeignName": "USDT-EUREP",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "USDT",
+            "ForeignName": "USDT-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "USDT",
+            "ForeignName": "USDT-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "USDT",
+            "ForeignName": "USDT-USDEP",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "USDT",
+            "ForeignName": "USDT-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UVX",
+            "ForeignName": "UVX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UZZ",
+            "ForeignName": "UZZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UZZ",
+            "ForeignName": "UZZ-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "UZZ",
+            "ForeignName": "UZZ-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VAL",
+            "ForeignName": "VAL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VAL",
+            "ForeignName": "VAL-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VAPEX",
+            "ForeignName": "VAPEX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VARIUS",
+            "ForeignName": "VARIUS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VAULT",
+            "ForeignName": "VAULT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VCX",
+            "ForeignName": "VCX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VDA",
+            "ForeignName": "VDA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VDL",
+            "ForeignName": "VDL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VECO",
+            "ForeignName": "VECO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VEGI",
+            "ForeignName": "VEGI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VEIL",
+            "ForeignName": "VEIL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VEN",
+            "ForeignName": "VEN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VERA",
+            "ForeignName": "VERA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VERS",
+            "ForeignName": "VERS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VESTX",
+            "ForeignName": "VESTX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VESTX",
+            "ForeignName": "VESTX-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VGW",
+            "ForeignName": "VGW-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VIOG",
+            "ForeignName": "VIOG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VIP",
+            "ForeignName": "VIP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VIPS",
+            "ForeignName": "VIPS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VIPS",
+            "ForeignName": "VIPS-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VIRA_OLD",
+            "ForeignName": "VIRA_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VIRAX",
+            "ForeignName": "VIRAX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VIR",
+            "ForeignName": "VIR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VIR",
+            "ForeignName": "VIR-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VIRIDI",
+            "ForeignName": "VIRIDI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VITES",
+            "ForeignName": "VITES-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLC_OLD2",
+            "ForeignName": "VLC_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLC_OLD",
+            "ForeignName": "VLC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLC",
+            "ForeignName": "VLC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLM",
+            "ForeignName": "VLM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLM",
+            "ForeignName": "VLM-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLS",
+            "ForeignName": "VLS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLU_OLD",
+            "ForeignName": "VLU_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLU_OLD",
+            "ForeignName": "VLU_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLU_OLD",
+            "ForeignName": "VLU_OLD-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLU_OLD",
+            "ForeignName": "VLU_OLD-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLU",
+            "ForeignName": "VLU-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLU",
+            "ForeignName": "VLU-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLU",
+            "ForeignName": "VLU-RUB",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLU",
+            "ForeignName": "VLU-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VLX",
+            "ForeignName": "VLX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VN",
+            "ForeignName": "VN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VNS",
+            "ForeignName": "VNS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VOT",
+            "ForeignName": "VOT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VOX",
+            "ForeignName": "VOX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VPC",
+            "ForeignName": "VPC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VPS",
+            "ForeignName": "VPS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VRBX",
+            "ForeignName": "VRBX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VRS",
+            "ForeignName": "VRS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VSL",
+            "ForeignName": "VSL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VSL",
+            "ForeignName": "VSL-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VSTR",
+            "ForeignName": "VSTR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VULC",
+            "ForeignName": "VULC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "VZH",
+            "ForeignName": "VZH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WAC",
+            "ForeignName": "WAC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WAGE",
+            "ForeignName": "WAGE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WAVES",
+            "ForeignName": "WAVES-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WAVES",
+            "ForeignName": "WAVES-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WBET_OLD",
+            "ForeignName": "WBET_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WC_OLD",
+            "ForeignName": "WC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WC",
+            "ForeignName": "WC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WCC",
+            "ForeignName": "WCC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WCF",
+            "ForeignName": "WCF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WCH",
+            "ForeignName": "WCH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WDF",
+            "ForeignName": "WDF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WEALTH",
+            "ForeignName": "WEALTH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WEB",
+            "ForeignName": "WEB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WEB",
+            "ForeignName": "WEB-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WFR_OLD",
+            "ForeignName": "WFR_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WGR",
+            "ForeignName": "WGR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WGR",
+            "ForeignName": "WGR-USDC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WILD",
+            "ForeignName": "WILD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WILD",
+            "ForeignName": "WILD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WINGE",
+            "ForeignName": "WINGE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WIX",
+            "ForeignName": "WIX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WMP",
+            "ForeignName": "WMP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WMPRO",
+            "ForeignName": "WMPRO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WTC",
+            "ForeignName": "WTC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WTP",
+            "ForeignName": "WTP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WTP",
+            "ForeignName": "WTP-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WTP",
+            "ForeignName": "WTP-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WVC",
+            "ForeignName": "WVC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WXC_OLD2",
+            "ForeignName": "WXC_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WXC_OLD",
+            "ForeignName": "WXC_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WXC",
+            "ForeignName": "WXC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "WYX",
+            "ForeignName": "WYX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "X12",
+            "ForeignName": "X12-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "X12",
+            "ForeignName": "X12-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "X12",
+            "ForeignName": "X12-EURPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "X12",
+            "ForeignName": "X12-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XAC",
+            "ForeignName": "XAC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XAC",
+            "ForeignName": "XAC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XAGC",
+            "ForeignName": "XAGC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XARON",
+            "ForeignName": "XARON-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XAT_OLD",
+            "ForeignName": "XAT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XBC",
+            "ForeignName": "XBC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XBC",
+            "ForeignName": "XBC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XBC",
+            "ForeignName": "XBC-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XBC",
+            "ForeignName": "XBC-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XBI",
+            "ForeignName": "XBI-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XBM",
+            "ForeignName": "XBM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XBM",
+            "ForeignName": "XBM-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XBRC",
+            "ForeignName": "XBRC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XBY",
+            "ForeignName": "XBY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XCZM",
+            "ForeignName": "XCZM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XDNA",
+            "ForeignName": "XDNA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XEF",
+            "ForeignName": "XEF-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XEM",
+            "ForeignName": "XEM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XEM",
+            "ForeignName": "XEM-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XEP",
+            "ForeignName": "XEP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XEUR",
+            "ForeignName": "XEUR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XFUEL",
+            "ForeignName": "XFUEL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XG",
+            "ForeignName": "XG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XGCS",
+            "ForeignName": "XGCS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XGG",
+            "ForeignName": "XGG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XGOD",
+            "ForeignName": "XGOD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XGOX",
+            "ForeignName": "XGOX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XGOX",
+            "ForeignName": "XGOX-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XHK_OLD2",
+            "ForeignName": "XHK_OLD2-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XHK_OLD3",
+            "ForeignName": "XHK_OLD3-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XHK_OLD",
+            "ForeignName": "XHK_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XIM",
+            "ForeignName": "XIM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XIM",
+            "ForeignName": "XIM-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XIND",
+            "ForeignName": "XIND-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XLA_OLD",
+            "ForeignName": "XLA_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XLA",
+            "ForeignName": "XLA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XLM",
+            "ForeignName": "XLM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XLM",
+            "ForeignName": "XLM-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XLN",
+            "ForeignName": "XLN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XLP",
+            "ForeignName": "XLP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XMCC",
+            "ForeignName": "XMCC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XMN",
+            "ForeignName": "XMN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XMR",
+            "ForeignName": "XMR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XMR",
+            "ForeignName": "XMR-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XMR",
+            "ForeignName": "XMR-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XMV",
+            "ForeignName": "XMV-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XNB",
+            "ForeignName": "XNB-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XNK_OLD",
+            "ForeignName": "XNK_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XNK_OLD",
+            "ForeignName": "XNK_OLD-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XNK",
+            "ForeignName": "XNK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XNK",
+            "ForeignName": "XNK-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XNODE",
+            "ForeignName": "XNODE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XNS",
+            "ForeignName": "XNS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XON",
+            "ForeignName": "XON-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XP",
+            "ForeignName": "XP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XPTX",
+            "ForeignName": "XPTX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XRC",
+            "ForeignName": "XRC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XRP",
+            "ForeignName": "XRP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XRP",
+            "ForeignName": "XRP-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XRP",
+            "ForeignName": "XRP-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XRP",
+            "ForeignName": "XRP-USDT_OLD",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XRP",
+            "ForeignName": "XRP-USDT_OLD2",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XSM",
+            "ForeignName": "XSM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XT3",
+            "ForeignName": "XT3-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XTA_OLD",
+            "ForeignName": "XTA_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XTA",
+            "ForeignName": "XTA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XTM",
+            "ForeignName": "XTM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XTR",
+            "ForeignName": "XTR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XVG",
+            "ForeignName": "XVG-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "XZC",
+            "ForeignName": "XZC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "YFI",
+            "ForeignName": "YFI-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "YFR",
+            "ForeignName": "YFR-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "YFX",
+            "ForeignName": "YFX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "YFX",
+            "ForeignName": "YFX-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "YFX",
+            "ForeignName": "YFX-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "YO",
+            "ForeignName": "YO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "YOLK",
+            "ForeignName": "YOLK-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "YTN_OLD",
+            "ForeignName": "YTN_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "YTN",
+            "ForeignName": "YTN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "YUSRA",
+            "ForeignName": "YUSRA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "YUSRA",
+            "ForeignName": "YUSRA-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZAR",
+            "ForeignName": "ZAR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZBA",
+            "ForeignName": "ZBA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZBK",
+            "ForeignName": "ZBK-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZCH",
+            "ForeignName": "ZCH-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZCN",
+            "ForeignName": "ZCN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZCNOX",
+            "ForeignName": "ZCNOX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZCR_OLD",
+            "ForeignName": "ZCR_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZCR",
+            "ForeignName": "ZCR-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZCR",
+            "ForeignName": "ZCR-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZCRT",
+            "ForeignName": "ZCRT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZEC",
+            "ForeignName": "ZEC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZEC",
+            "ForeignName": "ZEC-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZEC",
+            "ForeignName": "ZEC-USDT",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZENN",
+            "ForeignName": "ZENN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZER",
+            "ForeignName": "ZER-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZER",
+            "ForeignName": "ZER-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZEUS_OLD",
+            "ForeignName": "ZEUS_OLD-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZEUS",
+            "ForeignName": "ZEUS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZIJA",
+            "ForeignName": "ZIJA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZIO",
+            "ForeignName": "ZIO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZIOS",
+            "ForeignName": "ZIOS-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZLN",
+            "ForeignName": "ZLN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZLP",
+            "ForeignName": "ZLP-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZNCO",
+            "ForeignName": "ZNCO-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZNN",
+            "ForeignName": "ZNN-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZNY",
+            "ForeignName": "ZNY-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZNZ",
+            "ForeignName": "ZNZ-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZOC",
+            "ForeignName": "ZOC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZPPL",
+            "ForeignName": "ZPPL-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZRX",
+            "ForeignName": "ZRX-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZUBE",
+            "ForeignName": "ZUBE-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZUKA",
+            "ForeignName": "ZUKA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZULA",
+            "ForeignName": "ZULA-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZUM",
+            "ForeignName": "ZUM-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZUM",
+            "ForeignName": "ZUM-ETH",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZVT",
+            "ForeignName": "ZVT-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZYON",
+            "ForeignName": "ZYON-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZZC",
+            "ForeignName": "ZZC-BTC",
+            "Exchange": "CREX24",
+            "Ignore": true
+        },
+        {
+            "Symbol": "ZZC",
+            "ForeignName": "ZZC-USDPM",
+            "Exchange": "CREX24",
+            "Ignore": true
+        }
+    ]
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/blockstatecom/go-bitcoind v0.0.0-20180820094557-9dedf42af7c3
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b // indirect
 	github.com/btcsuite/btcd v0.21.0-beta // indirect
+	github.com/carterjones/signalr v0.3.5
 	github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054 // indirect
 	github.com/chromedp/cdproto v0.0.0-20200709115526-d1f6fc58448b
 	github.com/chromedp/chromedp v0.5.3

--- a/internal/pkg/exchange-scrapers/APIScraper.go
+++ b/internal/pkg/exchange-scrapers/APIScraper.go
@@ -1,8 +1,9 @@
 package scrapers
 
 import (
-	"github.com/ethereum/go-ethereum/common"
 	"io"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/diadata-org/diadata/pkg/dia"
 )
@@ -23,6 +24,7 @@ func init() {
 	exchanges[dia.BinanceExchange] = dia.Exchange{Name: dia.BinanceExchange, Centralized: true}
 	exchanges[dia.GnosisExchange] = dia.Exchange{Name: dia.GnosisExchange, Centralized: false, Contract: common.HexToAddress("0x6F400810b62df8E13fded51bE75fF5393eaa841F"), BlockChain: blockchains[dia.Ethereum]}
 	exchanges[dia.KrakenExchange] = dia.Exchange{Name: dia.KrakenExchange, Centralized: true}
+	exchanges[dia.CREX24Exchange] = dia.Exchange{Name: dia.CREX24Exchange, Centralized: true}
 	exchanges[dia.BitfinexExchange] = dia.Exchange{Name: dia.BitfinexExchange, Centralized: true}
 	exchanges[dia.BitBayExchange] = dia.Exchange{Name: dia.BitBayExchange, Centralized: true}
 	exchanges[dia.BittrexExchange] = dia.Exchange{Name: dia.BittrexExchange, Centralized: true}
@@ -88,6 +90,8 @@ func NewAPIScraper(exchange string, key string, secret string) APIScraper {
 		return NewBittrexScraper(exchanges[dia.BittrexExchange])
 	case dia.CoinBaseExchange:
 		return NewCoinBaseScraper(exchanges[dia.CoinBaseExchange])
+	case dia.CREX24Exchange:
+		return NewCREX24Scraper(exchanges[dia.CREX24Exchange])
 	case dia.KrakenExchange:
 		return NewKrakenScraper(key, secret, exchanges[dia.KrakenExchange])
 	case dia.HitBTCExchange:

--- a/internal/pkg/exchange-scrapers/CREX24Scraper.go
+++ b/internal/pkg/exchange-scrapers/CREX24Scraper.go
@@ -1,0 +1,243 @@
+package scrapers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/carterjones/signalr"
+	"github.com/carterjones/signalr/hubs"
+	"github.com/diadata-org/diadata/pkg/dia"
+)
+
+type CREX24ApiInstrument struct {
+	Symbol       string `json:"symbol"`
+	BaseCurrency string `json:"baseCurrency"`
+}
+
+type CREX24ApiTrade struct {
+	Price     string `json:"P"`
+	Volume    string `json:"V"`
+	Side      string `json:"S"`
+	Timestamp int64  `json:"T"`
+}
+
+type CREX24ApiTradeUpdate struct {
+	I  string
+	NT []CREX24ApiTrade
+}
+
+// CREX24 Scraper is a scraper for collecting trades from the CREX24 signalR api
+type CREX24Scraper struct {
+	client *signalr.Client
+	msgId  int
+	// signalR Connection
+	connectLock sync.RWMutex
+	connected   bool
+	// closed
+	closed bool
+	// pair scrapers
+	pairScrapers map[string]*CREX24PairScraper
+	exchangeName string
+	chanTrades   chan *dia.Trade
+}
+
+func NewCREX24Scraper(exchange dia.Exchange) *CREX24Scraper {
+	s := &CREX24Scraper{
+		pairScrapers: make(map[string]*CREX24PairScraper),
+		exchangeName: exchange.Name,
+		chanTrades:   make(chan *dia.Trade),
+		connected:    false,
+		closed:       false,
+		msgId:        1,
+	}
+	return s
+}
+
+// connect establishes a signalR connection to CREX24
+func (s *CREX24Scraper) connect() error {
+	s.client = signalr.New(
+		"api.crex24.com",
+		"1.5",
+		"/signalr",
+		`[{"name": "publicCryptoHub"}]`,
+		nil,
+	)
+	msgHandler := s.handleMessage
+	panicIfErr := func(err error) {
+		if err != nil {
+			log.Panic(err)
+		}
+	}
+	err := s.client.Run(msgHandler, panicIfErr)
+	if err != nil {
+		return errors.New("CREX24Scraper: Could not establish signalR connection")
+	}
+	s.connected = true
+	return nil
+}
+
+func (s *CREX24Scraper) Channel() chan *dia.Trade {
+	return s.chanTrades
+}
+
+func (s *CREX24Scraper) Close() error {
+	if s.closed {
+		return errors.New("CREX24Scraper: Already closed")
+	}
+	s.closed = true
+	s.connectLock.Lock()
+	defer s.connectLock.Unlock()
+	if s.connected {
+		s.client.Close()
+		s.connected = false
+	}
+	return nil
+}
+
+func (s *CREX24Scraper) NormalizePair(pair dia.Pair) (dia.Pair, error) {
+	return dia.Pair{}, nil
+}
+
+func (s *CREX24Scraper) handleMessage(msg signalr.Message) {
+	if s.closed {
+		return
+	}
+	for _, data := range msg.M {
+		if data.M == "UpdateSource" {
+			arguments := data.A
+			payload, ok := arguments[1].(string)
+			var parsedUpdate CREX24ApiTradeUpdate
+			if ok {
+				json.NewDecoder(strings.NewReader(payload)).Decode(&parsedUpdate)
+				s.sendTradesToChannel(&parsedUpdate)
+			}
+		}
+	}
+}
+
+func (s *CREX24Scraper) sendTradesToChannel(update *CREX24ApiTradeUpdate) {
+	ps := s.pairScrapers[update.I]
+	pair := ps.Pair()
+	for _, trade := range update.NT {
+		price, pok := strconv.ParseFloat(trade.Price, 64)
+		volume, vok := strconv.ParseFloat(trade.Volume, 64)
+		if pok == nil && vok == nil {
+			t := &dia.Trade{
+				Pair:           pair.ForeignName,
+				Price:          price,
+				Symbol:         pair.Symbol,
+				Volume:         volume,
+				Time:           time.Unix(trade.Timestamp, 0),
+				ForeignTradeID: "",
+				Source:         dia.CREX24Exchange,
+			}
+			s.chanTrades <- t
+			log.Info("got trade: ", t)
+		}
+	}
+}
+
+func (s *CREX24Scraper) FetchAvailablePairs() (pairs []dia.Pair, err error) {
+	resp, err := http.Get("https://api.crex24.com/v2/public/instruments")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var parsedPairs []CREX24ApiInstrument
+	err = json.NewDecoder(resp.Body).Decode(&parsedPairs)
+	if err != nil {
+		return nil, err
+	}
+
+	var results = make([]dia.Pair, len(parsedPairs))
+	for i := 0; i < len(parsedPairs); i++ {
+		results[i] = dia.Pair{
+			Symbol:      parsedPairs[i].BaseCurrency,
+			ForeignName: parsedPairs[i].Symbol,
+			Ignore:      false,
+			Exchange:    s.exchangeName,
+		}
+	}
+
+	return results, nil
+}
+
+func (s *CREX24Scraper) ScrapePair(pair dia.Pair) (PairScraper, error) {
+	if s.closed {
+		return nil, errors.New("CREX24Scraper: Call ScrapePair on closed scraper")
+	}
+
+	s.connectLock.Lock()
+	defer s.connectLock.Unlock()
+	if !s.connected {
+		// create the signalR connection lazily for the first pair scraper
+		if err := s.connect(); err != nil {
+			return nil, errors.New("CREX24Scraper: Could not establish signalR connection")
+		}
+	}
+
+	msg := hubs.ClientMsg{
+		H: "publicCryptoHub",
+		M: "joinTradeHistory",
+		A: []interface{}{pair.ForeignName},
+		I: s.msgId,
+	}
+
+	err := s.client.Send(msg)
+	s.msgId += 1
+
+	if err != nil {
+		return nil, errors.New("CREX24Scraper: could not send subscription signalR message")
+	}
+
+	ps := &CREX24PairScraper{
+		parent: s,
+		pair:   pair,
+	}
+
+	s.pairScrapers[pair.ForeignName] = ps
+
+	return ps, nil
+}
+
+type CREX24PairScraper struct {
+	parent *CREX24Scraper
+	pair   dia.Pair
+}
+
+func (ps *CREX24PairScraper) Close() error {
+	s := ps.parent
+	if s.closed {
+		return errors.New("CREX24Scraper: Scraper already closed")
+	}
+	msg := hubs.ClientMsg{
+		H: "publicCryptoHub",
+		M: "leaveTradeHistory",
+		A: []interface{}{ps.pair.ForeignName},
+		I: ps.parent.msgId,
+	}
+	err := ps.parent.client.Send(msg)
+	ps.parent.msgId += 1
+	if err != nil {
+		return errors.New("CREX24Scraper: Could not send unsubscribe signalR message")
+	}
+	return nil
+}
+
+func (ps *CREX24PairScraper) Error() error {
+	if ps.parent.closed {
+		return errors.New("Scraper has been closed")
+	} else {
+		return nil
+	}
+}
+
+func (ps *CREX24PairScraper) Pair() dia.Pair {
+	return ps.pair
+}

--- a/pkg/dia/Config.go
+++ b/pkg/dia/Config.go
@@ -40,6 +40,7 @@ const (
 	ZeroxExchange     = "0x"
 	KyberExchange     = "Kyber"
 	BitMaxExchange    = "Bitmax"
+	CREX24Exchange    = "CREX24"
 )
 
 const (
@@ -77,6 +78,7 @@ func Exchanges() []string {
 		KyberExchange,
 		BitMaxExchange,
 		PanCakeSwap,
+		CREX24Exchange,
 	}
 }
 


### PR DESCRIPTION
Dear all, 

the CREX24Scraper works fine now as far as I can see. 
Please have a look at this and give it a try.


I am a bit unsure about the correct usage of the `dia.Pair` struct. I am currently simply taking the response from the [CREX24 API ](https://api.crex24.com/v2/public/instruments) and I'm mapping the values like this: 
```golang
dia.Pair{
    Symbol:      parsedPairs[i].BaseCurrency,
    ForeignName: parsedPairs[i].Symbol,
    Ignore:      false,
    Exchange:    s.exchangeName,
}
```

**Architecture:** There is one bidirectional signalR connection to CREX24. After subscribing for a trade pair by sending a message, CREX24 will send trade updates over this connection to the Scraper. The Scraper maps them to `dia.Trade` and sends them into the go channel. 

I chose to not initialize the websocket/signalR connection in `NewCREX24Scraper` but instead lazily when the first ScrapePair is called. This way there won't be any blockage when running `pairDiscoveryService/main.go`. I chose to make `ScrapePair` block until the connection is established (once) and the subscription message has been sent somewhat analogous to the BinanceScraper. 

Looking forward to your feedback and I'd be happy to roll up my sleeves again in case you spot something that needs improvement. 

Cheers