### PR TITLE
Fix the query limit issue for The CryptoPunks trade scraper

### DIFF
--- a/internal/pkg/nftTrade-scrapers/cryptopunks.go
+++ b/internal/pkg/nftTrade-scrapers/cryptopunks.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/diadata-org/diadata/config/nftContracts/cryptopunk"
@@ -14,6 +15,7 @@ import (
 
 	// "github.com/diadata-org/diadata/pkg/dia/helpers/ethhelper"
 	models "github.com/diadata-org/diadata/pkg/model"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -35,7 +37,7 @@ func NewCryptoPunkScraper(rdb *models.RelDB) *CryptoPunkScraper {
 	// if err != nil {
 	// 	log.Error("Error connecting Eth Client")
 	// }
-	connection, err := ethclient.Dial("add your infura link here")
+	connection, err := ethclient.Dial("node url")
 	if err != nil {
 		log.Error("Error connecting Eth Client")
 	}
@@ -94,6 +96,7 @@ func (scraper *CryptoPunkScraper) FetchTrades() (trades []dia.NFTTrade, err erro
 			scraper.lastBlockNumber = big.NewInt(3919706)
 		}
 	}
+	scraper.lastBlockNumber = big.NewInt(12653867)
 	filterer, err := cryptopunk.NewCryptoPunksMarketFilterer(scraper.contractAddress, scraper.tradescraper.ethConnection)
 	if err != nil {
 		return nil, err
@@ -107,8 +110,13 @@ func (scraper *CryptoPunkScraper) FetchTrades() (trades []dia.NFTTrade, err erro
 
 	// TODO: It's a good practise to stay a litlle behind the head.
 	endBlockNumber := header.Number.Uint64() - 18
+	endBlockNumber = 12653869
+	// We need the cryptopunk abi to unpack the transfer event.
+	abi, err := abi.JSON(strings.NewReader(string(cryptopunk.CryptoPunksMarketABI)))
+	if err != nil {
+		return nil, err
+	}
 	trades = make([]dia.NFTTrade, 0)
-
 	// Reduce the window size while there is an query limit error.
 	for {
 		fmt.Println("lastBlockNumber, endBlockNumber: ", scraper.lastBlockNumber.Uint64(), endBlockNumber)
@@ -127,32 +135,62 @@ func (scraper *CryptoPunkScraper) FetchTrades() (trades []dia.NFTTrade, err erro
 			return nil, err
 		}
 
+		log.Infof("iter: %v", iter)
 		// Iter over FilterPunkBought events.
 		for iter.Next() {
 			// TODO: What value should i use for the blockchain argument?
-			nft, err := scraper.tradescraper.datastore.GetNFT(scraper.contractAddress, "ethereum", iter.Event.PunkIndex.String())
+			// nft, err := scraper.tradescraper.datastore.GetNFT(scraper.contractAddress, "ethereum", iter.Event.PunkIndex.String())
+			// if err != nil {
+			// 	// TODO: should we continue if we failed to get NFT from the db or should we fail!
+			// 	// continue
+			// 	return nil, err
+			// }
+
+			// QUICK HACK: this is a workaround to a Cryptopunks contract bug that leads to an empty ToAddress.
+			tx, err := scraper.tradescraper.ethConnection.TransactionReceipt(context.TODO(), iter.Event.Raw.TxHash)
 			if err != nil {
-				// TODO: should we continue if we failed to get NFT from the db or should we fail!
+				// TODO: should we continue if we failed to get tx or should we fail!
 				// continue
 				return nil, err
 			}
-			trades = append(trades, dia.NFTTrade{
-				NFT:         nft,
-				BlockNumber: big.NewInt(int64(iter.Event.Raw.BlockNumber)),
-				// TODO: Event.Value is in ETH value, how we can convert it to a USD value using
-				// a internal function?
-				PriceUSD:    float64(iter.Event.Value.Uint64()),
-				FromAddress: iter.Event.FromAddress,
-				ToAddress:   iter.Event.ToAddress,
-				// TODO: exchange name? any Idea?
-				Exchange: "",
-			})
+			log.Info("tx: ", tx.TxHash.Hex())
+
+			var transferEvent struct {
+				From  common.Address
+				To    common.Address
+				Value *big.Int
+			}
+
+			for _, vLog := range tx.Logs {
+				log.Info("log", vLog)
+				err := abi.UnpackIntoInterface(&transferEvent, "Transfer", vLog.Data)
+				if err == nil {
+					log.Info("found a Transfer event")
+
+					log.Info("event: ", transferEvent)
+					transferEvent.To = common.BytesToAddress(vLog.Topics[2].Bytes())
+					break
+				}
+			}
+
+			// trades = append(trades, dia.NFTTrade{
+			// 	NFT:         nft,
+			// 	BlockNumber: big.NewInt(int64(iter.Event.Raw.BlockNumber)),
+			// 	// TODO: Event.Value is in ETH value, how we can convert it to a USD value using
+			// 	// a internal function?
+			// 	PriceUSD:    float64(iter.Event.Value.Uint64()),
+			// 	FromAddress: iter.Event.FromAddress,
+			// 	ToAddress:   iter.Event.ToAddress,
+			// 	// TODO: exchange name? any Idea?
+			// 	Exchange: "",
+			// })
 
 			log.Infof("got trade: ")
 			log.Infof("iter: %v", iter)
 			log.Info("price: ", float64(iter.Event.Value.Uint64()))
 			log.Info("from address: ", iter.Event.FromAddress)
 			log.Info("to address: ", iter.Event.ToAddress)
+			log.Info("to address(from the tx Transfer event): ", transferEvent.To)
 			log.Info("tx: ", iter.Event.Raw.TxHash)
 			log.Info("blockNumber: ", big.NewInt(int64(iter.Event.Raw.BlockNumber)))
 			log.Info("id: ", iter.Event.PunkIndex.String())


### PR DESCRIPTION
### Refs
#408 
### Description
This PR will fix two mentioned problems in the original PR.
Here are my solutions:
> 1. For the initial run, you get the error: "error filtering FilterPunkBought: query returned more than 10000 results". So I'm afraid we'll have to fetch these in smaller chunks.

Now I'm using a sliding window of block ranges and it will reduce the window size by half whenever a limit error occurred.

> The trading data does not seem to be correct. The prices seem off and I think you're also fetching offers (price: 0 and to address zero address). See two examples below (I added the etherscan links to the transactions for your convenience).

Actually looks like that the txhash for the second mentioned event is `0xe5ba2e2ce07749beaddd15ad2ec2b30e678139ac76da88056588cf8055d441c0` and not `0x24f9fb3383f1b76db29668fa2f714a22fbb4208b58806158d0300a9e61fc6417` and it's just a PunkBought event for a zero price buy!

