### PR TITLE
Identify Exchange Symbol Ticker - HitBTC 1.3

### DIFF
--- a/config/verifiedSymbols/verifiedSymbols.json
+++ b/config/verifiedSymbols/verifiedSymbols.json
@@ -48,7 +48,7 @@
     {
       "Exchange": "HitBTC",
       "BatchNumber": "1",
-      "VerifiedBy": [""]     
+      "VerifiedBy": ["goojal"]     
     },
     {
       "Exchange": "OKEx",


### PR DESCRIPTION
Submission for gitcoin bounty: [Identify Exchange Symbol Ticker - HitBTC 1.3](https://gitcoin.co/issue/diadata-org/diadata/474/100026279).
Adds my handle to verifiedSymbols.json for HitBTC batch 1.
Closes #474.