### PR TITLE
Identify Exchange Symbol Ticker - HitBTC 2.2

### DIFF
--- a/config/verifiedSymbols/verifiedSymbols.json
+++ b/config/verifiedSymbols/verifiedSymbols.json
@@ -48,7 +48,7 @@
     {
       "Exchange": "HitBTC",
       "BatchNumber": "1",
-      "VerifiedBy": [""]     
+      "VerifiedBy": ["goojal"]     
     },
     {
       "Exchange": "OKEx",

--- a/config/verifiedSymbols/verifiedSymbols.json
+++ b/config/verifiedSymbols/verifiedSymbols.json
@@ -53,7 +53,7 @@
     {
       "Exchange": "HitBTC",
       "BatchNumber": "2",
-      "VerifiedBy": ["antonyip"]     
+      "VerifiedBy": ["antonyip", "goojal"]     
     },
     {
       "Exchange": "OKEx",


### PR DESCRIPTION
Submission for gitcoin bounty: [Identify Exchange Symbol Ticker - HitBTC 2.2](https://gitcoin.co/issue/diadata-org/diadata/482/100026339).
Adds my handle to verifiedSymbols.json for HitBTC batch 1.
Closes #482.