### PR TITLE
Add ftx exchange scraper

### DIFF
--- a/config/FTX.json
+++ b/config/FTX.json
@@ -1,0 +1,3052 @@
+{
+    "Coins": [
+        {
+            "Symbol": "1INCH",
+            "ForeignName": "1INCH/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AAPL",
+            "ForeignName": "AAPL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AAVE",
+            "ForeignName": "AAVE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AAVE",
+            "ForeignName": "AAVE/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ABNB",
+            "ForeignName": "ABNB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ACB",
+            "ForeignName": "ACB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AGLD",
+            "ForeignName": "AGLD/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AKRO",
+            "ForeignName": "AKRO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AKRO",
+            "ForeignName": "AKRO/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALCX",
+            "ForeignName": "ALCX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALEPH",
+            "ForeignName": "ALEPH/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALICE",
+            "ForeignName": "ALICE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALPHA",
+            "ForeignName": "ALPHA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AMC",
+            "ForeignName": "AMC/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AMD",
+            "ForeignName": "AMD/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AMPL",
+            "ForeignName": "AMPL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AMPL",
+            "ForeignName": "AMPL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AMZN",
+            "ForeignName": "AMZN/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "APHA",
+            "ForeignName": "APHA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ARKK",
+            "ForeignName": "ARKK/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ASD",
+            "ForeignName": "ASD/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ATLAS",
+            "ForeignName": "ATLAS/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AUDIO",
+            "ForeignName": "AUDIO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AUDIO",
+            "ForeignName": "AUDIO/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AURY",
+            "ForeignName": "AURY/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AVAX",
+            "ForeignName": "AVAX/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AVAX",
+            "ForeignName": "AVAX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AVAX",
+            "ForeignName": "AVAX/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "AXS",
+            "ForeignName": "AXS/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BABA",
+            "ForeignName": "BABA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BADGER",
+            "ForeignName": "BADGER/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BAL",
+            "ForeignName": "BAL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BAL",
+            "ForeignName": "BAL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BAND",
+            "ForeignName": "BAND/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BAO",
+            "ForeignName": "BAO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BAR",
+            "ForeignName": "BAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BAT",
+            "ForeignName": "BAT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BB",
+            "ForeignName": "BB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BCH",
+            "ForeignName": "BCH/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BCH",
+            "ForeignName": "BCH/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BCH",
+            "ForeignName": "BCH/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BICO",
+            "ForeignName": "BICO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BILI",
+            "ForeignName": "BILI/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BIT",
+            "ForeignName": "BIT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BITO",
+            "ForeignName": "BITO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BITW",
+            "ForeignName": "BITW/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BLT",
+            "ForeignName": "BLT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BNB",
+            "ForeignName": "BNB/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BNB",
+            "ForeignName": "BNB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BNB",
+            "ForeignName": "BNB/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BNT",
+            "ForeignName": "BNT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BNTX",
+            "ForeignName": "BNTX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BOBA",
+            "ForeignName": "BOBA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BRZ",
+            "ForeignName": "BRZ/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BRZ",
+            "ForeignName": "BRZ/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC/BRZ",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC/EUR",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC/TRYB",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BTC",
+            "ForeignName": "BTC/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BYND",
+            "ForeignName": "BYND/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "C98",
+            "ForeignName": "C98/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CAD",
+            "ForeignName": "CAD/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CEL",
+            "ForeignName": "CEL/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CEL",
+            "ForeignName": "CEL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CGC",
+            "ForeignName": "CGC/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CHR",
+            "ForeignName": "CHR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CHZ",
+            "ForeignName": "CHZ/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CHZ",
+            "ForeignName": "CHZ/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CITY",
+            "ForeignName": "CITY/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CLV",
+            "ForeignName": "CLV/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "COIN",
+            "ForeignName": "COIN/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "COMP",
+            "ForeignName": "COMP/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "COMP",
+            "ForeignName": "COMP/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CONV",
+            "ForeignName": "CONV/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "COPE",
+            "ForeignName": "COPE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CQT",
+            "ForeignName": "CQT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CREAM",
+            "ForeignName": "CREAM/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CREAM",
+            "ForeignName": "CREAM/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CRO",
+            "ForeignName": "CRO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CRON",
+            "ForeignName": "CRON/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CRV",
+            "ForeignName": "CRV/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CUSDT",
+            "ForeignName": "CUSDT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CUSDT",
+            "ForeignName": "CUSDT/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CVC",
+            "ForeignName": "CVC/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DAI",
+            "ForeignName": "DAI/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DAI",
+            "ForeignName": "DAI/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DAWN",
+            "ForeignName": "DAWN/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DENT",
+            "ForeignName": "DENT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DFL",
+            "ForeignName": "DFL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DKNG",
+            "ForeignName": "DKNG/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DMG",
+            "ForeignName": "DMG/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DMG",
+            "ForeignName": "DMG/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DODO",
+            "ForeignName": "DODO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DOGE",
+            "ForeignName": "DOGE/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DOGE",
+            "ForeignName": "DOGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DOGE",
+            "ForeignName": "DOGE/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DOT",
+            "ForeignName": "DOT/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DOT",
+            "ForeignName": "DOT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DOT",
+            "ForeignName": "DOT/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DYDX",
+            "ForeignName": "DYDX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EDEN",
+            "ForeignName": "EDEN/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EMB",
+            "ForeignName": "EMB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ENJ",
+            "ForeignName": "ENJ/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ENS",
+            "ForeignName": "ENS/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH/BRZ",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH/EUR",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETH",
+            "ForeignName": "ETH/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETHE",
+            "ForeignName": "ETHE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EUR",
+            "ForeignName": "EUR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "FB",
+            "ForeignName": "FB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "FIDA",
+            "ForeignName": "FIDA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "FIDA",
+            "ForeignName": "FIDA/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "FRONT",
+            "ForeignName": "FRONT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "FRONT",
+            "ForeignName": "FRONT/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "FTM",
+            "ForeignName": "FTM/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "FTT",
+            "ForeignName": "FTT/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "FTT",
+            "ForeignName": "FTT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "FTT",
+            "ForeignName": "FTT/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GAL",
+            "ForeignName": "GAL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GALA",
+            "ForeignName": "GALA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GBP",
+            "ForeignName": "GBP/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GBTC",
+            "ForeignName": "GBTC/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GDX",
+            "ForeignName": "GDX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GDXJ",
+            "ForeignName": "GDXJ/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GENE",
+            "ForeignName": "GENE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GLD",
+            "ForeignName": "GLD/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GLXY",
+            "ForeignName": "GLXY/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GME",
+            "ForeignName": "GME/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GODS",
+            "ForeignName": "GODS/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GOG",
+            "ForeignName": "GOG/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GOOGL",
+            "ForeignName": "GOOGL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GRT",
+            "ForeignName": "GRT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GT",
+            "ForeignName": "GT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HGET",
+            "ForeignName": "HGET/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HGET",
+            "ForeignName": "HGET/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HMT",
+            "ForeignName": "HMT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HNT",
+            "ForeignName": "HNT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HNT",
+            "ForeignName": "HNT/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HOLY",
+            "ForeignName": "HOLY/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HOOD",
+            "ForeignName": "HOOD/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HT",
+            "ForeignName": "HT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HUM",
+            "ForeignName": "HUM/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HXRO",
+            "ForeignName": "HXRO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HXRO",
+            "ForeignName": "HXRO/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "IMX",
+            "ForeignName": "IMX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "INTER",
+            "ForeignName": "INTER/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "JET",
+            "ForeignName": "JET/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "JOE",
+            "ForeignName": "JOE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "JST",
+            "ForeignName": "JST/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "KIN",
+            "ForeignName": "KIN/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "KNC",
+            "ForeignName": "KNC/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "KNC",
+            "ForeignName": "KNC/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "KSHIB",
+            "ForeignName": "KSHIB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LEO",
+            "ForeignName": "LEO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LINA",
+            "ForeignName": "LINA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LINK",
+            "ForeignName": "LINK/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LINK",
+            "ForeignName": "LINK/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LINK",
+            "ForeignName": "LINK/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LRC",
+            "ForeignName": "LRC/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LTC",
+            "ForeignName": "LTC/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LTC",
+            "ForeignName": "LTC/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LTC",
+            "ForeignName": "LTC/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LUA",
+            "ForeignName": "LUA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LUA",
+            "ForeignName": "LUA/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MANA",
+            "ForeignName": "MANA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MAPS",
+            "ForeignName": "MAPS/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MAPS",
+            "ForeignName": "MAPS/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MATH",
+            "ForeignName": "MATH/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MATH",
+            "ForeignName": "MATH/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MATIC",
+            "ForeignName": "MATIC/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MATIC",
+            "ForeignName": "MATIC/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MBS",
+            "ForeignName": "MBS/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MCB",
+            "ForeignName": "MCB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MEDIA",
+            "ForeignName": "MEDIA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MER",
+            "ForeignName": "MER/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MKR",
+            "ForeignName": "MKR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MKR",
+            "ForeignName": "MKR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MNGO",
+            "ForeignName": "MNGO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MOB",
+            "ForeignName": "MOB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MOB",
+            "ForeignName": "MOB/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MRNA",
+            "ForeignName": "MRNA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MSOL",
+            "ForeignName": "MSOL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MSTR",
+            "ForeignName": "MSTR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MTA",
+            "ForeignName": "MTA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MTA",
+            "ForeignName": "MTA/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MTL",
+            "ForeignName": "MTL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "NEXO",
+            "ForeignName": "NEXO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "NFLX",
+            "ForeignName": "NFLX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "NIO",
+            "ForeignName": "NIO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "NOK",
+            "ForeignName": "NOK/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "NVDA",
+            "ForeignName": "NVDA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "OKB",
+            "ForeignName": "OKB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "OMG",
+            "ForeignName": "OMG/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ORBS",
+            "ForeignName": "ORBS/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "OXY",
+            "ForeignName": "OXY/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "OXY",
+            "ForeignName": "OXY/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PAXG",
+            "ForeignName": "PAXG/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PAXG",
+            "ForeignName": "PAXG/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PENN",
+            "ForeignName": "PENN/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PERP",
+            "ForeignName": "PERP/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PFE",
+            "ForeignName": "PFE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "POLIS",
+            "ForeignName": "POLIS/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PORT",
+            "ForeignName": "PORT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PROM",
+            "ForeignName": "PROM/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PSG",
+            "ForeignName": "PSG/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PTU",
+            "ForeignName": "PTU/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PUNDIX",
+            "ForeignName": "PUNDIX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PYPL",
+            "ForeignName": "PYPL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "QI",
+            "ForeignName": "QI/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "RAMP",
+            "ForeignName": "RAMP/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "RAY",
+            "ForeignName": "RAY/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "REEF",
+            "ForeignName": "REEF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "REN",
+            "ForeignName": "REN/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "RNDR",
+            "ForeignName": "RNDR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ROOK",
+            "ForeignName": "ROOK/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ROOK",
+            "ForeignName": "ROOK/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "RSR",
+            "ForeignName": "RSR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "RUNE",
+            "ForeignName": "RUNE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "RUNE",
+            "ForeignName": "RUNE/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SAND",
+            "ForeignName": "SAND/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SECO",
+            "ForeignName": "SECO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SHIB",
+            "ForeignName": "SHIB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SKL",
+            "ForeignName": "SKL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SLND",
+            "ForeignName": "SLND/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SLP",
+            "ForeignName": "SLP/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SLRS",
+            "ForeignName": "SLRS/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SLV",
+            "ForeignName": "SLV/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SNX",
+            "ForeignName": "SNX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SNY",
+            "ForeignName": "SNY/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SOL",
+            "ForeignName": "SOL/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SOL",
+            "ForeignName": "SOL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SOL",
+            "ForeignName": "SOL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SPELL",
+            "ForeignName": "SPELL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SPY",
+            "ForeignName": "SPY/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SQ",
+            "ForeignName": "SQ/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SRM",
+            "ForeignName": "SRM/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SRM",
+            "ForeignName": "SRM/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "STARS",
+            "ForeignName": "STARS/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "STEP",
+            "ForeignName": "STEP/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "STETH",
+            "ForeignName": "STETH/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "STMX",
+            "ForeignName": "STMX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "STORJ",
+            "ForeignName": "STORJ/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "STSOL",
+            "ForeignName": "STSOL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SUN",
+            "ForeignName": "SUN/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SUSHI",
+            "ForeignName": "SUSHI/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SUSHI",
+            "ForeignName": "SUSHI/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SUSHI",
+            "ForeignName": "SUSHI/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SXP",
+            "ForeignName": "SXP/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SXP",
+            "ForeignName": "SXP/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SXP",
+            "ForeignName": "SXP/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TLM",
+            "ForeignName": "TLM/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TLRY",
+            "ForeignName": "TLRY/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TOMO",
+            "ForeignName": "TOMO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TOMO",
+            "ForeignName": "TOMO/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TONCOIN",
+            "ForeignName": "TONCOIN/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRU",
+            "ForeignName": "TRU/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRU",
+            "ForeignName": "TRU/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRX",
+            "ForeignName": "TRX/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRX",
+            "ForeignName": "TRX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRX",
+            "ForeignName": "TRX/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRYB",
+            "ForeignName": "TRYB/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TSLA",
+            "ForeignName": "TSLA/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TSLA",
+            "ForeignName": "TSLA/DOGE",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TSLA",
+            "ForeignName": "TSLA/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TSM",
+            "ForeignName": "TSM/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TULIP",
+            "ForeignName": "TULIP/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TWTR",
+            "ForeignName": "TWTR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "UBER",
+            "ForeignName": "UBER/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "UBXT",
+            "ForeignName": "UBXT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "UBXT",
+            "ForeignName": "UBXT/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "UNI",
+            "ForeignName": "UNI/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "UNI",
+            "ForeignName": "UNI/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "UNI",
+            "ForeignName": "UNI/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "USDT",
+            "ForeignName": "USDT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "USO",
+            "ForeignName": "USO/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "VGX",
+            "ForeignName": "VGX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "WAVES",
+            "ForeignName": "WAVES/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "WBTC",
+            "ForeignName": "WBTC/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "WBTC",
+            "ForeignName": "WBTC/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "WNDR",
+            "ForeignName": "WNDR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "WRX",
+            "ForeignName": "WRX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "WRX",
+            "ForeignName": "WRX/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XAUT",
+            "ForeignName": "XAUT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XAUT",
+            "ForeignName": "XAUT/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XRP",
+            "ForeignName": "XRP/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XRP",
+            "ForeignName": "XRP/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XRP",
+            "ForeignName": "XRP/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "YFI",
+            "ForeignName": "YFI/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "YFI",
+            "ForeignName": "YFI/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "YFI",
+            "ForeignName": "YFI/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "YFII",
+            "ForeignName": "YFII/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ZM",
+            "ForeignName": "ZM/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ZRX",
+            "ForeignName": "ZRX/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ADABEAR",
+            "ForeignName": "ADABEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ADABULL",
+            "ForeignName": "ADABULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ADAHALF",
+            "ForeignName": "ADAHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ADAHEDGE",
+            "ForeignName": "ADAHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALGOBEAR",
+            "ForeignName": "ALGOBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALGOBULL",
+            "ForeignName": "ALGOBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALGOHALF",
+            "ForeignName": "ALGOHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALGOHEDGE",
+            "ForeignName": "ALGOHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALTBEAR",
+            "ForeignName": "ALTBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALTBULL",
+            "ForeignName": "ALTBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALTHALF",
+            "ForeignName": "ALTHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ALTHEDGE",
+            "ForeignName": "ALTHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ASDBEAR",
+            "ForeignName": "ASDBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ASDBEAR",
+            "ForeignName": "ASDBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ASDBULL",
+            "ForeignName": "ASDBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ASDBULL",
+            "ForeignName": "ASDBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ASDHALF",
+            "ForeignName": "ASDHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ASDHEDGE",
+            "ForeignName": "ASDHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ATOMBEAR",
+            "ForeignName": "ATOMBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ATOMBULL",
+            "ForeignName": "ATOMBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ATOMHALF",
+            "ForeignName": "ATOMHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ATOMHEDGE",
+            "ForeignName": "ATOMHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BALBEAR",
+            "ForeignName": "BALBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BALBEAR",
+            "ForeignName": "BALBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BALBULL",
+            "ForeignName": "BALBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BALBULL",
+            "ForeignName": "BALBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BALHALF",
+            "ForeignName": "BALHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BALHEDGE",
+            "ForeignName": "BALHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BCHBEAR",
+            "ForeignName": "BCHBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BCHBEAR",
+            "ForeignName": "BCHBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BCHBULL",
+            "ForeignName": "BCHBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BCHBULL",
+            "ForeignName": "BCHBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BCHHALF",
+            "ForeignName": "BCHHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BCHHEDGE",
+            "ForeignName": "BCHHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BEAR",
+            "ForeignName": "BEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BEAR",
+            "ForeignName": "BEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BEARSHIT",
+            "ForeignName": "BEARSHIT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BNBBEAR",
+            "ForeignName": "BNBBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BNBBEAR",
+            "ForeignName": "BNBBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BNBBULL",
+            "ForeignName": "BNBBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BNBBULL",
+            "ForeignName": "BNBBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BNBHALF",
+            "ForeignName": "BNBHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BNBHEDGE",
+            "ForeignName": "BNBHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BSVBEAR",
+            "ForeignName": "BSVBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BSVBEAR",
+            "ForeignName": "BSVBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BSVBULL",
+            "ForeignName": "BSVBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BSVBULL",
+            "ForeignName": "BSVBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BSVHALF",
+            "ForeignName": "BSVHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BSVHEDGE",
+            "ForeignName": "BSVHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BULL",
+            "ForeignName": "BULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BULL",
+            "ForeignName": "BULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BULLSHIT",
+            "ForeignName": "BULLSHIT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BVOL",
+            "ForeignName": "BVOL/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BVOL",
+            "ForeignName": "BVOL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "BVOL",
+            "ForeignName": "BVOL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "COMPBEAR",
+            "ForeignName": "COMPBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "COMPBEAR",
+            "ForeignName": "COMPBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "COMPBULL",
+            "ForeignName": "COMPBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "COMPBULL",
+            "ForeignName": "COMPBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "COMPHALF",
+            "ForeignName": "COMPHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "COMPHEDGE",
+            "ForeignName": "COMPHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CUSDTBEAR",
+            "ForeignName": "CUSDTBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CUSDTBEAR",
+            "ForeignName": "CUSDTBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CUSDTBULL",
+            "ForeignName": "CUSDTBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CUSDTBULL",
+            "ForeignName": "CUSDTBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CUSDTHALF",
+            "ForeignName": "CUSDTHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "CUSDTHEDGE",
+            "ForeignName": "CUSDTHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DEFIBEAR",
+            "ForeignName": "DEFIBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DEFIBEAR",
+            "ForeignName": "DEFIBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DEFIBULL",
+            "ForeignName": "DEFIBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DEFIBULL",
+            "ForeignName": "DEFIBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DEFIHALF",
+            "ForeignName": "DEFIHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DEFIHEDGE",
+            "ForeignName": "DEFIHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DOGEBEAR2021",
+            "ForeignName": "DOGEBEAR2021/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DOGEBULL",
+            "ForeignName": "DOGEBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DOGEHALF",
+            "ForeignName": "DOGEHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DOGEHEDGE",
+            "ForeignName": "DOGEHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DRGNBEAR",
+            "ForeignName": "DRGNBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DRGNBULL",
+            "ForeignName": "DRGNBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DRGNHALF",
+            "ForeignName": "DRGNHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "DRGNHEDGE",
+            "ForeignName": "DRGNHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EOSBEAR",
+            "ForeignName": "EOSBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EOSBEAR",
+            "ForeignName": "EOSBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EOSBULL",
+            "ForeignName": "EOSBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EOSBULL",
+            "ForeignName": "EOSBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EOSHALF",
+            "ForeignName": "EOSHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EOSHEDGE",
+            "ForeignName": "EOSHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETCBEAR",
+            "ForeignName": "ETCBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETCBULL",
+            "ForeignName": "ETCBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETCHALF",
+            "ForeignName": "ETCHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETCHEDGE",
+            "ForeignName": "ETCHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETHBEAR",
+            "ForeignName": "ETHBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETHBEAR",
+            "ForeignName": "ETHBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETHBULL",
+            "ForeignName": "ETHBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETHBULL",
+            "ForeignName": "ETHBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETHHALF",
+            "ForeignName": "ETHHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ETHHEDGE",
+            "ForeignName": "ETHHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EXCHBEAR",
+            "ForeignName": "EXCHBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EXCHBULL",
+            "ForeignName": "EXCHBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EXCHHALF",
+            "ForeignName": "EXCHHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "EXCHHEDGE",
+            "ForeignName": "EXCHHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GRTBEAR",
+            "ForeignName": "GRTBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "GRTBULL",
+            "ForeignName": "GRTBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HALF",
+            "ForeignName": "HALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HALFSHIT",
+            "ForeignName": "HALFSHIT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HEDGE",
+            "ForeignName": "HEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HEDGESHIT",
+            "ForeignName": "HEDGESHIT/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HTBEAR",
+            "ForeignName": "HTBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HTBULL",
+            "ForeignName": "HTBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HTHALF",
+            "ForeignName": "HTHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "HTHEDGE",
+            "ForeignName": "HTHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "IBVOL",
+            "ForeignName": "IBVOL/BTC",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "IBVOL",
+            "ForeignName": "IBVOL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "IBVOL",
+            "ForeignName": "IBVOL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "KNCBEAR",
+            "ForeignName": "KNCBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "KNCBEAR",
+            "ForeignName": "KNCBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "KNCBULL",
+            "ForeignName": "KNCBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "KNCBULL",
+            "ForeignName": "KNCBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "KNCHALF",
+            "ForeignName": "KNCHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "KNCHEDGE",
+            "ForeignName": "KNCHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LEOBEAR",
+            "ForeignName": "LEOBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LEOBULL",
+            "ForeignName": "LEOBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LEOHALF",
+            "ForeignName": "LEOHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LEOHEDGE",
+            "ForeignName": "LEOHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LINKBEAR",
+            "ForeignName": "LINKBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LINKBEAR",
+            "ForeignName": "LINKBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LINKBULL",
+            "ForeignName": "LINKBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LINKBULL",
+            "ForeignName": "LINKBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LINKHALF",
+            "ForeignName": "LINKHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LINKHEDGE",
+            "ForeignName": "LINKHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LTCBEAR",
+            "ForeignName": "LTCBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LTCBEAR",
+            "ForeignName": "LTCBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LTCBULL",
+            "ForeignName": "LTCBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LTCBULL",
+            "ForeignName": "LTCBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LTCHALF",
+            "ForeignName": "LTCHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "LTCHEDGE",
+            "ForeignName": "LTCHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MATICBEAR2021",
+            "ForeignName": "MATICBEAR2021/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MATICBULL",
+            "ForeignName": "MATICBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MATICHALF",
+            "ForeignName": "MATICHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MATICHEDGE",
+            "ForeignName": "MATICHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MIDBEAR",
+            "ForeignName": "MIDBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MIDBULL",
+            "ForeignName": "MIDBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MIDHALF",
+            "ForeignName": "MIDHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MIDHEDGE",
+            "ForeignName": "MIDHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MKRBEAR",
+            "ForeignName": "MKRBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "MKRBULL",
+            "ForeignName": "MKRBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "OKBBEAR",
+            "ForeignName": "OKBBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "OKBBULL",
+            "ForeignName": "OKBBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "OKBHALF",
+            "ForeignName": "OKBHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "OKBHEDGE",
+            "ForeignName": "OKBHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PAXGBEAR",
+            "ForeignName": "PAXGBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PAXGBULL",
+            "ForeignName": "PAXGBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PAXGHALF",
+            "ForeignName": "PAXGHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PAXGHEDGE",
+            "ForeignName": "PAXGHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PRIVBEAR",
+            "ForeignName": "PRIVBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PRIVBULL",
+            "ForeignName": "PRIVBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PRIVHALF",
+            "ForeignName": "PRIVHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "PRIVHEDGE",
+            "ForeignName": "PRIVHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SUSHIBEAR",
+            "ForeignName": "SUSHIBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SUSHIBULL",
+            "ForeignName": "SUSHIBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SXPBEAR",
+            "ForeignName": "SXPBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SXPBULL",
+            "ForeignName": "SXPBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SXPHALF",
+            "ForeignName": "SXPHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SXPHALF",
+            "ForeignName": "SXPHALF/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "SXPHEDGE",
+            "ForeignName": "SXPHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "THETABEAR",
+            "ForeignName": "THETABEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "THETABULL",
+            "ForeignName": "THETABULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "THETAHALF",
+            "ForeignName": "THETAHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "THETAHEDGE",
+            "ForeignName": "THETAHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TOMOBEAR2021",
+            "ForeignName": "TOMOBEAR2021/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TOMOBULL",
+            "ForeignName": "TOMOBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TOMOHALF",
+            "ForeignName": "TOMOHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TOMOHEDGE",
+            "ForeignName": "TOMOHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRXBEAR",
+            "ForeignName": "TRXBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRXBULL",
+            "ForeignName": "TRXBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRXHALF",
+            "ForeignName": "TRXHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRXHEDGE",
+            "ForeignName": "TRXHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRYBBEAR",
+            "ForeignName": "TRYBBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRYBBULL",
+            "ForeignName": "TRYBBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRYBHALF",
+            "ForeignName": "TRYBHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "TRYBHEDGE",
+            "ForeignName": "TRYBHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "UNISWAPBEAR",
+            "ForeignName": "UNISWAPBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "UNISWAPBULL",
+            "ForeignName": "UNISWAPBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "USDTBEAR",
+            "ForeignName": "USDTBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "USDTBULL",
+            "ForeignName": "USDTBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "USDTHALF",
+            "ForeignName": "USDTHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "USDTHEDGE",
+            "ForeignName": "USDTHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "VETBEAR",
+            "ForeignName": "VETBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "VETBEAR",
+            "ForeignName": "VETBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "VETBULL",
+            "ForeignName": "VETBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "VETBULL",
+            "ForeignName": "VETBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "VETHEDGE",
+            "ForeignName": "VETHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XAUTBEAR",
+            "ForeignName": "XAUTBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XAUTBULL",
+            "ForeignName": "XAUTBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XAUTHALF",
+            "ForeignName": "XAUTHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XAUTHEDGE",
+            "ForeignName": "XAUTHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XLMBEAR",
+            "ForeignName": "XLMBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XLMBULL",
+            "ForeignName": "XLMBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XRPBEAR",
+            "ForeignName": "XRPBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XRPBEAR",
+            "ForeignName": "XRPBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XRPBULL",
+            "ForeignName": "XRPBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XRPBULL",
+            "ForeignName": "XRPBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XRPHALF",
+            "ForeignName": "XRPHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XRPHEDGE",
+            "ForeignName": "XRPHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XTZBEAR",
+            "ForeignName": "XTZBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XTZBEAR",
+            "ForeignName": "XTZBEAR/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XTZBULL",
+            "ForeignName": "XTZBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XTZBULL",
+            "ForeignName": "XTZBULL/USDT",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XTZHALF",
+            "ForeignName": "XTZHALF/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "XTZHEDGE",
+            "ForeignName": "XTZHEDGE/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ZECBEAR",
+            "ForeignName": "ZECBEAR/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        },
+        {
+            "Symbol": "ZECBULL",
+            "ForeignName": "ZECBULL/USD",
+            "Exchange": "FTX",
+            "Ignore": false
+        }
+    ]
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/blockstatecom/go-bitcoind v0.0.0-20180820094557-9dedf42af7c3
 	github.com/btcsuite/btcd v0.21.0-beta // indirect
 	github.com/carterjones/signalr v0.3.5
+	github.com/cloudingcity/go-ftx v0.1.0
 	github.com/cnf/structhash v0.0.0-20180104161610-62a607eb0224
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/ethereum/go-ethereum v1.10.10
@@ -49,6 +50,7 @@ require (
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969 // indirect
+	github.com/streamingfast/binary v0.0.0-20210928223119-44fc44e4a0b5
 	github.com/streamingfast/solana-go v0.3.0
 	github.com/stretchr/testify v1.7.0
 	github.com/swaggo/swag v1.6.7

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,9 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/anaskhan96/soup v1.1.1 h1:Duux/0htS2Va7XLJ9qIakCSey790hg9OFRm2FwlMTy0=
 github.com/anaskhan96/soup v1.1.1/go.mod h1:pT5vs4HXDwA5y4KQCsKvnkpQd3D+joP7IqpiGskfWW0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
+github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
+github.com/andybalholm/brotli v1.0.1 h1:KqhlKozYbRtJvsPrrEeXcO+N2l6NYT5A2QAFmSULpEc=
+github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -185,6 +188,7 @@ github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytecodealliance/wasmtime-go v0.22.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
@@ -212,6 +216,8 @@ github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/cloudflare/cloudflare-go v0.14.0/go.mod h1:EnwdgGMaFOruiPZRFSgn+TsQ3hQ7C/YWzIGLeu5c304=
+github.com/cloudingcity/go-ftx v0.1.0 h1:/WB34yqNt7etsDhu3U3zqwxmGL0CUXGo8Lx8aZvIZzY=
+github.com/cloudingcity/go-ftx v0.1.0/go.mod h1:14kBHAVnyaQOwSV8iA+c8ha795TxBjRIbwE5R4tgIss=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -260,6 +266,7 @@ github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf/go.mod h1:eEKB0N0r
 github.com/dop251/goja v0.0.0-20211011172007-d99e4b8cbf48/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
 github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA7c8pLvoGndExHudxTDKZ84Pyvv+90pbBjbTz0Y=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -333,6 +340,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-numb/go-ftx v0.0.0-20211208060907-82614a9fd25b h1:uv7EVkoWM00kUKufIQk0KDzn5zsM+ARxtV1yB0DZ5TE=
+github.com/go-numb/go-ftx v0.0.0-20211208060907-82614a9fd25b/go.mod h1:sZs9S1a1GqrO5VBdM4ThWzdY/g/xJ7FPuuNhF7i26LM=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
@@ -443,6 +452,9 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -636,6 +648,7 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -657,8 +670,12 @@ github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.8/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.10.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.10.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.3 h1:dB4Bn0tN3wdCzQxnS8r06kV74qN/TAfaIS0bVE8h3jc=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.8/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.12.1 h1:/+xsCsk06wE38cyiqOR/o7U2fSftcH72xD+BQXmja/g=
+github.com/klauspost/compress v1.12.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
 github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
@@ -1018,9 +1035,14 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasthttp v1.21.0/go.mod h1:jjraHZVbKOXftJfsOYoAjaeygpj5hr8ermTRJNroD7A=
+github.com/valyala/fasthttp v1.23.0 h1:0ufwSD9BhWa6f8HWdmdq4FHQ23peRo3Ng/Qs8m5NcFs=
+github.com/valyala/fasthttp v1.23.0/go.mod h1:0mw2RjXGOzxf4NL2jni3gUQ7LfjjUSiG5sskOUUSEpU=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=
@@ -1195,6 +1217,7 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -1202,6 +1225,7 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210226101413-39120d07d75e/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
@@ -1307,6 +1331,7 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210223095934-7937bea0104d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/dia/Config.go
+++ b/pkg/dia/Config.go
@@ -16,7 +16,7 @@ const (
 	KrakenExchange     = "Kraken"
 	BitfinexExchange   = "Bitfinex"
 	BinanceExchange    = "Binance"
-	FTX                = "FTX"
+	FTXExchange        = "FTX"
 	Opyn               = "OPYN"
 	Premia             = "Premia"
 	BitBayExchange     = "BitBay"
@@ -76,6 +76,7 @@ func Exchanges() []string {
 		// FinageForex,
 		BitMaxExchange,
 		ZBExchange,
+		FTXExchange,
 		HuobiExchange,
 		BitBayExchange,
 		BittrexExchange,

--- a/pkg/dia/scraper/exchange-scrapers/APIScraper.go
+++ b/pkg/dia/scraper/exchange-scrapers/APIScraper.go
@@ -52,6 +52,7 @@ func init() {
 	Exchanges[dia.HitBTCExchange] = dia.Exchange{Name: dia.HitBTCExchange, Centralized: true, WatchdogDelay: watchdogDelay}
 	Exchanges[dia.SimexExchange] = dia.Exchange{Name: dia.SimexExchange, Centralized: true, WatchdogDelay: watchdogDelay}
 	Exchanges[dia.OKExExchange] = dia.Exchange{Name: dia.OKExExchange, Centralized: true, WatchdogDelay: watchdogDelay}
+	Exchanges[dia.FTXExchange] = dia.Exchange{Name: dia.FTXExchange, Centralized: true, WatchdogDelay: watchdogDelay}
 	Exchanges[dia.HuobiExchange] = dia.Exchange{Name: dia.HuobiExchange, Centralized: true, WatchdogDelay: watchdogDelay}
 	Exchanges[dia.LBankExchange] = dia.Exchange{Name: dia.LBankExchange, Centralized: true, WatchdogDelay: watchdogDelay}
 	Exchanges[dia.GateIOExchange] = dia.Exchange{Name: dia.GateIOExchange, Centralized: true, WatchdogDelay: watchdogDelay}
@@ -146,6 +147,8 @@ func NewAPIScraper(exchange string, scrape bool, key string, secret string, relD
 		return NewSimexScraper(Exchanges[dia.SimexExchange], scrape, relDB)
 	case dia.OKExExchange:
 		return NewOKExScraper(Exchanges[dia.OKExExchange], scrape, relDB)
+	case dia.FTXExchange:
+		return NewFTXScrapper(Exchanges[dia.FTXExchange], scrape, relDB)
 	case dia.HuobiExchange:
 		return NewHuobiScraper(Exchanges[dia.HuobiExchange], scrape, relDB)
 	case dia.LBankExchange:

--- a/pkg/dia/scraper/exchange-scrapers/FTXScraper.go
+++ b/pkg/dia/scraper/exchange-scrapers/FTXScraper.go
@@ -1,0 +1,295 @@
+package scrapers
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cloudingcity/go-ftx/ftx"
+	"github.com/cloudingcity/go-ftx/ftx/stream"
+
+	"github.com/diadata-org/diadata/pkg/dia"
+	models "github.com/diadata-org/diadata/pkg/model"
+)
+
+const (
+	spotTradingPair = "spot"
+	spotTradingBuy  = "buy"
+)
+
+// FTXScrapper is a scraper for FTX
+type FTXScrapper struct {
+	api *ftx.Client
+	ws  *stream.Conn
+
+	// signaling channels for session initialization and finishing
+	shutdown     chan nothing
+	shutdownDone chan nothing
+
+	// error handling; err should be read from error(), closed should be read from isTerminated()
+	// those two methods implement RW lock
+	errMutex    sync.RWMutex
+	err         error
+	closedMutex sync.RWMutex
+	closed      bool
+
+	// used to keep track of trading pairs that we subscribed to
+	pairScrapers map[string]*FTXPairScraper
+	exchangeName string
+	chanTrades   chan *dia.Trade
+	db           *models.RelDB
+}
+
+// NewFTXScrapper returns a new FTX scraper
+func NewFTXScrapper(exchange dia.Exchange, scrape bool, relDB *models.RelDB) *FTXScrapper {
+	s := &FTXScrapper{
+		shutdown:     make(chan nothing),
+		shutdownDone: make(chan nothing),
+		pairScrapers: make(map[string]*FTXPairScraper),
+		exchangeName: exchange.Name,
+		err:          nil,
+		chanTrades:   make(chan *dia.Trade),
+		db:           relDB,
+	}
+
+	client := ftx.New()
+	ws, err := client.Connect()
+	if err != nil {
+		log.Error(err)
+
+		return nil
+	}
+
+	s.ws = ws
+	s.api = client
+
+	if scrape {
+		go s.mainLoop()
+	}
+
+	return s
+}
+
+// Close unsubscribes data and closes any existing WebSocket connections, as well as channels of FTXPairScraper
+func (s *FTXScrapper) Close() error {
+	if s.isTerminated() {
+		return errors.New("FTXScrapper: Already closed")
+	}
+
+	// TODO: use sync once
+	close(s.shutdown)
+	<-s.shutdownDone
+
+	s.terminate()
+
+	return s.error()
+}
+
+// Channel returns a channel that can be used to receive trades
+func (s *FTXScrapper) Channel() chan *dia.Trade {
+	return s.chanTrades
+}
+
+// FetchAvailablePairs returns all traded pairs on FTX
+func (s *FTXScrapper) FetchAvailablePairs() (pairs []dia.ExchangePair, err error) {
+	markets, err := s.api.Markets.All()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range markets {
+		if m.Type != spotTradingPair {
+			continue
+		}
+
+		pairs = append(pairs, dia.ExchangePair{
+			Symbol:      m.BaseCurrency,
+			ForeignName: m.Name,
+			Exchange:    s.exchangeName,
+		})
+	}
+
+	return pairs, nil
+}
+
+// FillSymbolData adds the name to the asset underlying @symbol on FTX
+func (s *FTXScrapper) FillSymbolData(symbol string) (dia.Asset, error) {
+	return dia.Asset{Symbol: symbol}, nil
+}
+
+func (s *FTXScrapper) NormalizePair(pair dia.ExchangePair) (dia.ExchangePair, error) {
+	return pair, nil
+}
+
+// ScrapePair returns a PairScraper that can be used to get trades for a single pair from the FTX scraper
+func (s *FTXScrapper) ScrapePair(pair dia.ExchangePair) (PairScraper, error) {
+	if err := s.error(); err != nil {
+		return nil, err
+	}
+	if s.isTerminated() {
+		return nil, errors.New("FTXScrapper: Call ScrapePair on closed scraper")
+	}
+
+	ps := &FTXPairScraper{
+		parent: s,
+		pair:   pair,
+	}
+
+	s.pairScrapers[pair.ForeignName] = ps
+	if err := s.subscribe(pair); err != nil {
+		return nil, err
+	}
+
+	return ps, nil
+}
+
+func (s *FTXScrapper) mainLoop() {
+	go s.ping()
+
+	for {
+		resp, err := s.ws.Recv()
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+
+		select {
+		case <-s.shutdown:
+			log.Println("FTXScrapper: Shutting down main loop")
+			s.cleanup()
+
+			return
+		default:
+		}
+
+		switch v := resp.(type) {
+		case stream.Trade:
+			baseCurrency := strings.Split(v.Market, `/`)[0]
+			pair, err := s.db.GetExchangePairCache(s.exchangeName, v.Market)
+			if err != nil {
+				log.Error(err)
+			}
+
+			for _, trade := range v.Data {
+				volume := trade.Size
+				if trade.Side != spotTradingBuy {
+					volume = -volume
+				}
+
+				trade := &dia.Trade{
+					Symbol:       baseCurrency,
+					Pair:         v.Market,
+					Price:        trade.Price,
+					Time:         trade.Time,
+					Volume:       volume,
+					Source:       s.exchangeName,
+					VerifiedPair: pair.Verified,
+					BaseToken:    pair.UnderlyingPair.BaseToken,
+					QuoteToken:   pair.UnderlyingPair.QuoteToken,
+				}
+				if pair.Verified {
+					log.Infoln("Got verified trade", trade)
+				}
+
+				s.chanTrades <- trade
+			}
+		}
+	}
+}
+
+func (s *FTXScrapper) ping() {
+	t := time.NewTicker(time.Duration(15) * time.Second)
+	for {
+		select {
+		case <-s.shutdown:
+			log.Println("FTXScrapper: Shutting down ping loop")
+
+			return
+		case <-t.C:
+			if err := s.ws.Ping(); err != nil {
+				log.Warningf("FTXScrapper: Sending pings fail %s", err.Error())
+			}
+		}
+	}
+}
+
+func (s *FTXScrapper) cleanup() {
+	if err := s.ws.Close(); err != nil {
+		s.setError(err)
+	}
+
+	// TODO: use sync once
+	close(s.shutdownDone)
+}
+
+func (s *FTXScrapper) error() error {
+	s.errMutex.RLock()
+	defer s.errMutex.RUnlock()
+
+	return s.err
+}
+
+func (s *FTXScrapper) setError(err error) {
+	s.errMutex.Lock()
+	defer s.errMutex.Unlock()
+
+	s.err = err
+}
+
+func (s *FTXScrapper) isTerminated() bool {
+	s.closedMutex.RLock()
+	defer s.closedMutex.RUnlock()
+
+	return s.closed
+}
+
+func (s *FTXScrapper) terminate() {
+	s.closedMutex.Lock()
+	defer s.closedMutex.Unlock()
+
+	s.closed = true
+}
+
+func (s *FTXScrapper) subscribe(pair dia.ExchangePair) error {
+	return s.ws.Subscribe(stream.ChannelTrades, pair.ForeignName)
+}
+
+func (s *FTXScrapper) unsubscribe(pair dia.ExchangePair) error {
+	return s.ws.Unsubscribe(stream.ChannelTrades, pair.ForeignName)
+}
+
+// FTXPairScraper implements PairScraper for FTX
+type FTXPairScraper struct {
+	parent *FTXScrapper
+	pair   dia.ExchangePair
+	closed bool
+}
+
+// Error returns an error when the channel Channel() is closed
+// and nil otherwise
+func (p *FTXPairScraper) Error() error {
+	return p.parent.error()
+}
+
+// Pair returns the pair this scraper is subscribed to
+func (p *FTXPairScraper) Pair() dia.ExchangePair {
+	return p.pair
+}
+
+// Close stops listening for trades of the pair associated with the FTX scraper
+func (p *FTXPairScraper) Close() error {
+	if err := p.parent.error(); err != nil {
+		return err
+	}
+	if p.closed {
+		return errors.New("FTXPairScraper: Already closed")
+	}
+	if err := p.parent.unsubscribe(p.pair); err != nil {
+		return err
+	}
+
+	p.closed = true
+
+	return nil
+}


### PR DESCRIPTION
# Why need this change?:
- To add a new FTX scraper in diadata and the request originated from https://gitcoin.co/issue/diadata-org/diadata/505/100027344 and https://github.com/diadata-org/diadata/issues/505

# Changes made:
- Add FTX exchange to the config file
- Implement FTX Scraper
 