### PR TITLE
NFT Trades Scraper for Seaport Opensea contract on Ethereum

### DIFF
--- a/cmd/nftTradescrapers/main.go
+++ b/cmd/nftTradescrapers/main.go
@@ -96,7 +96,7 @@ func handleData(tradeChannel chan dia.NFTTrade, wg *sync.WaitGroup, rdb *models.
 
 		log.Infof("got trade: %s -> (%s) -> %s for %s (%.4f USD) \n", trade.FromAddress, trade.NFT.NFTClass.Name, trade.ToAddress, trade.Currency.Symbol, trade.PriceUSD)
 
-		err := rdb.SetNFTTradeToTable(trade, models.NfttradeCurrTable)
+		err := rdb.SetNFTTradeToTable(trade, models.NfttradeTable)
 		// err := rdb.SetNFTTradeToTable(trade, models.NfttradeSumeriaTable)
 		if err != nil {
 			var pgErr *pgconn.PgError

--- a/cmd/nftTradescrapers/main.go
+++ b/cmd/nftTradescrapers/main.go
@@ -93,9 +93,8 @@ func handleData(tradeChannel chan dia.NFTTrade, wg *sync.WaitGroup, rdb *models.
 			log.Error("error")
 			return
 		}
-		if 1 < 0 {
-			log.Infof("got trade: %s -> (%s) -> %s for %s (%.4f USD) \n", trade.FromAddress, trade.NFT.NFTClass.Name, trade.ToAddress, trade.Currency.Symbol, trade.PriceUSD)
-		}
+
+		log.Infof("got trade: %s -> (%s) -> %s for %s (%.4f USD) \n", trade.FromAddress, trade.NFT.NFTClass.Name, trade.ToAddress, trade.Currency.Symbol, trade.PriceUSD)
 
 		err := rdb.SetNFTTradeToTable(trade, models.NfttradeCurrTable)
 		// err := rdb.SetNFTTradeToTable(trade, models.NfttradeSumeriaTable)

--- a/cmd/nftTradescrapers/main.go
+++ b/cmd/nftTradescrapers/main.go
@@ -59,6 +59,9 @@ func main() {
 	case "OpenseaBAYC":
 		log.Println("NFT Trades Scraper: Start scraping trades from Opensea")
 		scraper = nfttradescrapers.NewOpenSeaBAYCScraper(rdb)
+	case "OpenseaSeaport":
+		log.Println("NFT Trades Scraper: Start scraping trades from Opensea Seaport contract")
+		scraper = nfttradescrapers.NewOpenSeaSeaportScraper(rdb)
 	case "LooksRare":
 		log.Println("NFT Trades Scraper: Start scraping trades from LooksRare")
 		scraper = nfttradescrapers.NewLooksRareScraper(rdb)

--- a/cmd/nftTradescrapers/main.go
+++ b/cmd/nftTradescrapers/main.go
@@ -81,7 +81,6 @@ func main() {
 	wg.Add(1)
 	go handleData(scraper.GetTradeChannel(), &wg, rdb)
 	defer wg.Wait()
-
 }
 
 func handleData(tradeChannel chan dia.NFTTrade, wg *sync.WaitGroup, rdb *models.RelDB) {

--- a/config/nftContracts/openseaseaport/openseaseaport.go
+++ b/config/nftContracts/openseaseaport/openseaseaport.go
@@ -1,0 +1,1335 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package openseaseaport
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// AdditionalRecipient is an auto generated low-level Go binding around an user-defined struct.
+type AdditionalRecipient struct {
+	Amount    *big.Int
+	Recipient common.Address
+}
+
+// AdvancedOrder is an auto generated low-level Go binding around an user-defined struct.
+type AdvancedOrder struct {
+	Parameters  OrderParameters
+	Numerator   *big.Int
+	Denominator *big.Int
+	Signature   []byte
+	ExtraData   []byte
+}
+
+// BasicOrderParameters is an auto generated low-level Go binding around an user-defined struct.
+type BasicOrderParameters struct {
+	ConsiderationToken                common.Address
+	ConsiderationIdentifier           *big.Int
+	ConsiderationAmount               *big.Int
+	Offerer                           common.Address
+	Zone                              common.Address
+	OfferToken                        common.Address
+	OfferIdentifier                   *big.Int
+	OfferAmount                       *big.Int
+	BasicOrderType                    uint8
+	StartTime                         *big.Int
+	EndTime                           *big.Int
+	ZoneHash                          [32]byte
+	Salt                              *big.Int
+	OffererConduitKey                 [32]byte
+	FulfillerConduitKey               [32]byte
+	TotalOriginalAdditionalRecipients *big.Int
+	AdditionalRecipients              []AdditionalRecipient
+	Signature                         []byte
+}
+
+// ConsiderationItem is an auto generated low-level Go binding around an user-defined struct.
+type ConsiderationItem struct {
+	ItemType             uint8
+	Token                common.Address
+	IdentifierOrCriteria *big.Int
+	StartAmount          *big.Int
+	EndAmount            *big.Int
+	Recipient            common.Address
+}
+
+// CriteriaResolver is an auto generated low-level Go binding around an user-defined struct.
+type CriteriaResolver struct {
+	OrderIndex    *big.Int
+	Side          uint8
+	Index         *big.Int
+	Identifier    *big.Int
+	CriteriaProof [][32]byte
+}
+
+// Execution is an auto generated low-level Go binding around an user-defined struct.
+type Execution struct {
+	Item       ReceivedItem
+	Offerer    common.Address
+	ConduitKey [32]byte
+}
+
+// Fulfillment is an auto generated low-level Go binding around an user-defined struct.
+type Fulfillment struct {
+	OfferComponents         []FulfillmentComponent
+	ConsiderationComponents []FulfillmentComponent
+}
+
+// FulfillmentComponent is an auto generated low-level Go binding around an user-defined struct.
+type FulfillmentComponent struct {
+	OrderIndex *big.Int
+	ItemIndex  *big.Int
+}
+
+// OfferItem is an auto generated low-level Go binding around an user-defined struct.
+type OfferItem struct {
+	ItemType             uint8
+	Token                common.Address
+	IdentifierOrCriteria *big.Int
+	StartAmount          *big.Int
+	EndAmount            *big.Int
+}
+
+// Order is an auto generated low-level Go binding around an user-defined struct.
+type Order struct {
+	Parameters OrderParameters
+	Signature  []byte
+}
+
+// OrderComponents is an auto generated low-level Go binding around an user-defined struct.
+type OrderComponents struct {
+	Offerer       common.Address
+	Zone          common.Address
+	Offer         []OfferItem
+	Consideration []ConsiderationItem
+	OrderType     uint8
+	StartTime     *big.Int
+	EndTime       *big.Int
+	ZoneHash      [32]byte
+	Salt          *big.Int
+	ConduitKey    [32]byte
+	Counter       *big.Int
+}
+
+// OrderParameters is an auto generated low-level Go binding around an user-defined struct.
+type OrderParameters struct {
+	Offerer                         common.Address
+	Zone                            common.Address
+	Offer                           []OfferItem
+	Consideration                   []ConsiderationItem
+	OrderType                       uint8
+	StartTime                       *big.Int
+	EndTime                         *big.Int
+	ZoneHash                        [32]byte
+	Salt                            *big.Int
+	ConduitKey                      [32]byte
+	TotalOriginalConsiderationItems *big.Int
+}
+
+// ReceivedItem is an auto generated low-level Go binding around an user-defined struct.
+type ReceivedItem struct {
+	ItemType   uint8
+	Token      common.Address
+	Identifier *big.Int
+	Amount     *big.Int
+	Recipient  common.Address
+}
+
+// SpentItem is an auto generated low-level Go binding around an user-defined struct.
+type SpentItem struct {
+	ItemType   uint8
+	Token      common.Address
+	Identifier *big.Int
+	Amount     *big.Int
+}
+
+// OpenseaseaportMetaData contains all meta data concerning the Openseaseaport contract.
+var OpenseaseaportMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"conduitController\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"BadContractSignature\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"BadFraction\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"BadReturnValueFromERC20OnTransfer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"}],\"name\":\"BadSignatureV\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ConsiderationCriteriaResolverOutOfRange\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"considerationIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"shortfallAmount\",\"type\":\"uint256\"}],\"name\":\"ConsiderationNotMet\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"CriteriaNotEnabledForItem\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256[]\",\"name\":\"identifiers\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"amounts\",\"type\":\"uint256[]\"}],\"name\":\"ERC1155BatchTransferGenericFailure\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"EtherTransferGenericFailure\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InexactFraction\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InsufficientEtherSupplied\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"Invalid1155BatchTransferEncoding\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidBasicOrderParameterEncoding\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"conduit\",\"type\":\"address\"}],\"name\":\"InvalidCallToConduit\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidCanceller\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"conduit\",\"type\":\"address\"}],\"name\":\"InvalidConduit\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidERC721TransferAmount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidFulfillmentComponentData\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"InvalidMsgValue\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidNativeOfferItem\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidProof\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"}],\"name\":\"InvalidRestrictedOrder\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidSignature\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidSigner\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidTime\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MismatchedFulfillmentOfferAndConsiderationComponents\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"enumSide\",\"name\":\"side\",\"type\":\"uint8\"}],\"name\":\"MissingFulfillmentComponentOnAggregation\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MissingItemAmount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MissingOriginalConsiderationItems\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"NoContract\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NoReentrantCalls\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NoSpecifiedOrdersAvailable\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OfferAndConsiderationRequiredOnFulfillment\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OfferCriteriaResolverOutOfRange\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"}],\"name\":\"OrderAlreadyFilled\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OrderCriteriaResolverOutOfRange\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"}],\"name\":\"OrderIsCancelled\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"}],\"name\":\"OrderPartiallyFilled\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"PartialFillsNotEnabledForOrder\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifier\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"TokenTransferGenericFailure\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UnresolvedConsiderationCriteria\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UnresolvedOfferCriteria\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UnusedItemParameters\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newCounter\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"}],\"name\":\"CounterIncremented\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"}],\"name\":\"OrderCancelled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifier\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"indexed\":false,\"internalType\":\"structSpentItem[]\",\"name\":\"offer\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifier\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"indexed\":false,\"internalType\":\"structReceivedItem[]\",\"name\":\"consideration\",\"type\":\"tuple[]\"}],\"name\":\"OrderFulfilled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"}],\"name\":\"OrderValidated\",\"type\":\"event\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"}],\"internalType\":\"structOfferItem[]\",\"name\":\"offer\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structConsiderationItem[]\",\"name\":\"consideration\",\"type\":\"tuple[]\"},{\"internalType\":\"enumOrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"startTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endTime\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"zoneHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"counter\",\"type\":\"uint256\"}],\"internalType\":\"structOrderComponents[]\",\"name\":\"orders\",\"type\":\"tuple[]\"}],\"name\":\"cancel\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"cancelled\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"}],\"internalType\":\"structOfferItem[]\",\"name\":\"offer\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structConsiderationItem[]\",\"name\":\"consideration\",\"type\":\"tuple[]\"},{\"internalType\":\"enumOrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"startTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endTime\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"zoneHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"totalOriginalConsiderationItems\",\"type\":\"uint256\"}],\"internalType\":\"structOrderParameters\",\"name\":\"parameters\",\"type\":\"tuple\"},{\"internalType\":\"uint120\",\"name\":\"numerator\",\"type\":\"uint120\"},{\"internalType\":\"uint120\",\"name\":\"denominator\",\"type\":\"uint120\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"structAdvancedOrder\",\"name\":\"advancedOrder\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"enumSide\",\"name\":\"side\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"identifier\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"criteriaProof\",\"type\":\"bytes32[]\"}],\"internalType\":\"structCriteriaResolver[]\",\"name\":\"criteriaResolvers\",\"type\":\"tuple[]\"},{\"internalType\":\"bytes32\",\"name\":\"fulfillerConduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"fulfillAdvancedOrder\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"fulfilled\",\"type\":\"bool\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"}],\"internalType\":\"structOfferItem[]\",\"name\":\"offer\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structConsiderationItem[]\",\"name\":\"consideration\",\"type\":\"tuple[]\"},{\"internalType\":\"enumOrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"startTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endTime\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"zoneHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"totalOriginalConsiderationItems\",\"type\":\"uint256\"}],\"internalType\":\"structOrderParameters\",\"name\":\"parameters\",\"type\":\"tuple\"},{\"internalType\":\"uint120\",\"name\":\"numerator\",\"type\":\"uint120\"},{\"internalType\":\"uint120\",\"name\":\"denominator\",\"type\":\"uint120\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"structAdvancedOrder[]\",\"name\":\"advancedOrders\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"enumSide\",\"name\":\"side\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"identifier\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"criteriaProof\",\"type\":\"bytes32[]\"}],\"internalType\":\"structCriteriaResolver[]\",\"name\":\"criteriaResolvers\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"itemIndex\",\"type\":\"uint256\"}],\"internalType\":\"structFulfillmentComponent[][]\",\"name\":\"offerFulfillments\",\"type\":\"tuple[][]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"itemIndex\",\"type\":\"uint256\"}],\"internalType\":\"structFulfillmentComponent[][]\",\"name\":\"considerationFulfillments\",\"type\":\"tuple[][]\"},{\"internalType\":\"bytes32\",\"name\":\"fulfillerConduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"maximumFulfilled\",\"type\":\"uint256\"}],\"name\":\"fulfillAvailableAdvancedOrders\",\"outputs\":[{\"internalType\":\"bool[]\",\"name\":\"availableOrders\",\"type\":\"bool[]\"},{\"components\":[{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifier\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structReceivedItem\",\"name\":\"item\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"}],\"internalType\":\"structExecution[]\",\"name\":\"executions\",\"type\":\"tuple[]\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"}],\"internalType\":\"structOfferItem[]\",\"name\":\"offer\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structConsiderationItem[]\",\"name\":\"consideration\",\"type\":\"tuple[]\"},{\"internalType\":\"enumOrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"startTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endTime\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"zoneHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"totalOriginalConsiderationItems\",\"type\":\"uint256\"}],\"internalType\":\"structOrderParameters\",\"name\":\"parameters\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"}],\"internalType\":\"structOrder[]\",\"name\":\"orders\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"itemIndex\",\"type\":\"uint256\"}],\"internalType\":\"structFulfillmentComponent[][]\",\"name\":\"offerFulfillments\",\"type\":\"tuple[][]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"itemIndex\",\"type\":\"uint256\"}],\"internalType\":\"structFulfillmentComponent[][]\",\"name\":\"considerationFulfillments\",\"type\":\"tuple[][]\"},{\"internalType\":\"bytes32\",\"name\":\"fulfillerConduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"maximumFulfilled\",\"type\":\"uint256\"}],\"name\":\"fulfillAvailableOrders\",\"outputs\":[{\"internalType\":\"bool[]\",\"name\":\"availableOrders\",\"type\":\"bool[]\"},{\"components\":[{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifier\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structReceivedItem\",\"name\":\"item\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"}],\"internalType\":\"structExecution[]\",\"name\":\"executions\",\"type\":\"tuple[]\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"considerationToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"considerationIdentifier\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"considerationAmount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"offerToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"offerIdentifier\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"offerAmount\",\"type\":\"uint256\"},{\"internalType\":\"enumBasicOrderType\",\"name\":\"basicOrderType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"startTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endTime\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"zoneHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"offererConduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"fulfillerConduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"totalOriginalAdditionalRecipients\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structAdditionalRecipient[]\",\"name\":\"additionalRecipients\",\"type\":\"tuple[]\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"}],\"internalType\":\"structBasicOrderParameters\",\"name\":\"parameters\",\"type\":\"tuple\"}],\"name\":\"fulfillBasicOrder\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"fulfilled\",\"type\":\"bool\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"}],\"internalType\":\"structOfferItem[]\",\"name\":\"offer\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structConsiderationItem[]\",\"name\":\"consideration\",\"type\":\"tuple[]\"},{\"internalType\":\"enumOrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"startTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endTime\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"zoneHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"totalOriginalConsiderationItems\",\"type\":\"uint256\"}],\"internalType\":\"structOrderParameters\",\"name\":\"parameters\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"}],\"internalType\":\"structOrder\",\"name\":\"order\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"fulfillerConduitKey\",\"type\":\"bytes32\"}],\"name\":\"fulfillOrder\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"fulfilled\",\"type\":\"bool\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"}],\"name\":\"getCounter\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"counter\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"}],\"internalType\":\"structOfferItem[]\",\"name\":\"offer\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structConsiderationItem[]\",\"name\":\"consideration\",\"type\":\"tuple[]\"},{\"internalType\":\"enumOrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"startTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endTime\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"zoneHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"counter\",\"type\":\"uint256\"}],\"internalType\":\"structOrderComponents\",\"name\":\"order\",\"type\":\"tuple\"}],\"name\":\"getOrderHash\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"}],\"name\":\"getOrderStatus\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"isValidated\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"isCancelled\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"totalFilled\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"totalSize\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"incrementCounter\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"newCounter\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"information\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"bytes32\",\"name\":\"domainSeparator\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"conduitController\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"}],\"internalType\":\"structOfferItem[]\",\"name\":\"offer\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structConsiderationItem[]\",\"name\":\"consideration\",\"type\":\"tuple[]\"},{\"internalType\":\"enumOrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"startTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endTime\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"zoneHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"totalOriginalConsiderationItems\",\"type\":\"uint256\"}],\"internalType\":\"structOrderParameters\",\"name\":\"parameters\",\"type\":\"tuple\"},{\"internalType\":\"uint120\",\"name\":\"numerator\",\"type\":\"uint120\"},{\"internalType\":\"uint120\",\"name\":\"denominator\",\"type\":\"uint120\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"structAdvancedOrder[]\",\"name\":\"advancedOrders\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"enumSide\",\"name\":\"side\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"identifier\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"criteriaProof\",\"type\":\"bytes32[]\"}],\"internalType\":\"structCriteriaResolver[]\",\"name\":\"criteriaResolvers\",\"type\":\"tuple[]\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"itemIndex\",\"type\":\"uint256\"}],\"internalType\":\"structFulfillmentComponent[]\",\"name\":\"offerComponents\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"itemIndex\",\"type\":\"uint256\"}],\"internalType\":\"structFulfillmentComponent[]\",\"name\":\"considerationComponents\",\"type\":\"tuple[]\"}],\"internalType\":\"structFulfillment[]\",\"name\":\"fulfillments\",\"type\":\"tuple[]\"}],\"name\":\"matchAdvancedOrders\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifier\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structReceivedItem\",\"name\":\"item\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"}],\"internalType\":\"structExecution[]\",\"name\":\"executions\",\"type\":\"tuple[]\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"}],\"internalType\":\"structOfferItem[]\",\"name\":\"offer\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structConsiderationItem[]\",\"name\":\"consideration\",\"type\":\"tuple[]\"},{\"internalType\":\"enumOrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"startTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endTime\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"zoneHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"totalOriginalConsiderationItems\",\"type\":\"uint256\"}],\"internalType\":\"structOrderParameters\",\"name\":\"parameters\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"}],\"internalType\":\"structOrder[]\",\"name\":\"orders\",\"type\":\"tuple[]\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"itemIndex\",\"type\":\"uint256\"}],\"internalType\":\"structFulfillmentComponent[]\",\"name\":\"offerComponents\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"orderIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"itemIndex\",\"type\":\"uint256\"}],\"internalType\":\"structFulfillmentComponent[]\",\"name\":\"considerationComponents\",\"type\":\"tuple[]\"}],\"internalType\":\"structFulfillment[]\",\"name\":\"fulfillments\",\"type\":\"tuple[]\"}],\"name\":\"matchOrders\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifier\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structReceivedItem\",\"name\":\"item\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"}],\"internalType\":\"structExecution[]\",\"name\":\"executions\",\"type\":\"tuple[]\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"contractName\",\"type\":\"string\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"offerer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"zone\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"}],\"internalType\":\"structOfferItem[]\",\"name\":\"offer\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enumItemType\",\"name\":\"itemType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"identifierOrCriteria\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"startAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endAmount\",\"type\":\"uint256\"},{\"internalType\":\"addresspayable\",\"name\":\"recipient\",\"type\":\"address\"}],\"internalType\":\"structConsiderationItem[]\",\"name\":\"consideration\",\"type\":\"tuple[]\"},{\"internalType\":\"enumOrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"startTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"endTime\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"zoneHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"conduitKey\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"totalOriginalConsiderationItems\",\"type\":\"uint256\"}],\"internalType\":\"structOrderParameters\",\"name\":\"parameters\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"}],\"internalType\":\"structOrder[]\",\"name\":\"orders\",\"type\":\"tuple[]\"}],\"name\":\"validate\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"validated\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// OpenseaseaportABI is the input ABI used to generate the binding from.
+// Deprecated: Use OpenseaseaportMetaData.ABI instead.
+var OpenseaseaportABI = OpenseaseaportMetaData.ABI
+
+// Openseaseaport is an auto generated Go binding around an Ethereum contract.
+type Openseaseaport struct {
+	OpenseaseaportCaller     // Read-only binding to the contract
+	OpenseaseaportTransactor // Write-only binding to the contract
+	OpenseaseaportFilterer   // Log filterer for contract events
+}
+
+// OpenseaseaportCaller is an auto generated read-only Go binding around an Ethereum contract.
+type OpenseaseaportCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OpenseaseaportTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type OpenseaseaportTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OpenseaseaportFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type OpenseaseaportFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OpenseaseaportSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type OpenseaseaportSession struct {
+	Contract     *Openseaseaport   // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// OpenseaseaportCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type OpenseaseaportCallerSession struct {
+	Contract *OpenseaseaportCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts         // Call options to use throughout this session
+}
+
+// OpenseaseaportTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type OpenseaseaportTransactorSession struct {
+	Contract     *OpenseaseaportTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts         // Transaction auth options to use throughout this session
+}
+
+// OpenseaseaportRaw is an auto generated low-level Go binding around an Ethereum contract.
+type OpenseaseaportRaw struct {
+	Contract *Openseaseaport // Generic contract binding to access the raw methods on
+}
+
+// OpenseaseaportCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type OpenseaseaportCallerRaw struct {
+	Contract *OpenseaseaportCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// OpenseaseaportTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type OpenseaseaportTransactorRaw struct {
+	Contract *OpenseaseaportTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewOpenseaseaport creates a new instance of Openseaseaport, bound to a specific deployed contract.
+func NewOpenseaseaport(address common.Address, backend bind.ContractBackend) (*Openseaseaport, error) {
+	contract, err := bindOpenseaseaport(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Openseaseaport{OpenseaseaportCaller: OpenseaseaportCaller{contract: contract}, OpenseaseaportTransactor: OpenseaseaportTransactor{contract: contract}, OpenseaseaportFilterer: OpenseaseaportFilterer{contract: contract}}, nil
+}
+
+// NewOpenseaseaportCaller creates a new read-only instance of Openseaseaport, bound to a specific deployed contract.
+func NewOpenseaseaportCaller(address common.Address, caller bind.ContractCaller) (*OpenseaseaportCaller, error) {
+	contract, err := bindOpenseaseaport(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OpenseaseaportCaller{contract: contract}, nil
+}
+
+// NewOpenseaseaportTransactor creates a new write-only instance of Openseaseaport, bound to a specific deployed contract.
+func NewOpenseaseaportTransactor(address common.Address, transactor bind.ContractTransactor) (*OpenseaseaportTransactor, error) {
+	contract, err := bindOpenseaseaport(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OpenseaseaportTransactor{contract: contract}, nil
+}
+
+// NewOpenseaseaportFilterer creates a new log filterer instance of Openseaseaport, bound to a specific deployed contract.
+func NewOpenseaseaportFilterer(address common.Address, filterer bind.ContractFilterer) (*OpenseaseaportFilterer, error) {
+	contract, err := bindOpenseaseaport(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &OpenseaseaportFilterer{contract: contract}, nil
+}
+
+// bindOpenseaseaport binds a generic wrapper to an already deployed contract.
+func bindOpenseaseaport(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(OpenseaseaportABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Openseaseaport *OpenseaseaportRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Openseaseaport.Contract.OpenseaseaportCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Openseaseaport *OpenseaseaportRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.OpenseaseaportTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Openseaseaport *OpenseaseaportRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.OpenseaseaportTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Openseaseaport *OpenseaseaportCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Openseaseaport.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Openseaseaport *OpenseaseaportTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Openseaseaport *OpenseaseaportTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetCounter is a free data retrieval call binding the contract method 0xf07ec373.
+//
+// Solidity: function getCounter(address offerer) view returns(uint256 counter)
+func (_Openseaseaport *OpenseaseaportCaller) GetCounter(opts *bind.CallOpts, offerer common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _Openseaseaport.contract.Call(opts, &out, "getCounter", offerer)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetCounter is a free data retrieval call binding the contract method 0xf07ec373.
+//
+// Solidity: function getCounter(address offerer) view returns(uint256 counter)
+func (_Openseaseaport *OpenseaseaportSession) GetCounter(offerer common.Address) (*big.Int, error) {
+	return _Openseaseaport.Contract.GetCounter(&_Openseaseaport.CallOpts, offerer)
+}
+
+// GetCounter is a free data retrieval call binding the contract method 0xf07ec373.
+//
+// Solidity: function getCounter(address offerer) view returns(uint256 counter)
+func (_Openseaseaport *OpenseaseaportCallerSession) GetCounter(offerer common.Address) (*big.Int, error) {
+	return _Openseaseaport.Contract.GetCounter(&_Openseaseaport.CallOpts, offerer)
+}
+
+// GetOrderHash is a free data retrieval call binding the contract method 0x79df72bd.
+//
+// Solidity: function getOrderHash((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256) order) view returns(bytes32 orderHash)
+func (_Openseaseaport *OpenseaseaportCaller) GetOrderHash(opts *bind.CallOpts, order OrderComponents) ([32]byte, error) {
+	var out []interface{}
+	err := _Openseaseaport.contract.Call(opts, &out, "getOrderHash", order)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetOrderHash is a free data retrieval call binding the contract method 0x79df72bd.
+//
+// Solidity: function getOrderHash((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256) order) view returns(bytes32 orderHash)
+func (_Openseaseaport *OpenseaseaportSession) GetOrderHash(order OrderComponents) ([32]byte, error) {
+	return _Openseaseaport.Contract.GetOrderHash(&_Openseaseaport.CallOpts, order)
+}
+
+// GetOrderHash is a free data retrieval call binding the contract method 0x79df72bd.
+//
+// Solidity: function getOrderHash((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256) order) view returns(bytes32 orderHash)
+func (_Openseaseaport *OpenseaseaportCallerSession) GetOrderHash(order OrderComponents) ([32]byte, error) {
+	return _Openseaseaport.Contract.GetOrderHash(&_Openseaseaport.CallOpts, order)
+}
+
+// GetOrderStatus is a free data retrieval call binding the contract method 0x46423aa7.
+//
+// Solidity: function getOrderStatus(bytes32 orderHash) view returns(bool isValidated, bool isCancelled, uint256 totalFilled, uint256 totalSize)
+func (_Openseaseaport *OpenseaseaportCaller) GetOrderStatus(opts *bind.CallOpts, orderHash [32]byte) (struct {
+	IsValidated bool
+	IsCancelled bool
+	TotalFilled *big.Int
+	TotalSize   *big.Int
+}, error) {
+	var out []interface{}
+	err := _Openseaseaport.contract.Call(opts, &out, "getOrderStatus", orderHash)
+
+	outstruct := new(struct {
+		IsValidated bool
+		IsCancelled bool
+		TotalFilled *big.Int
+		TotalSize   *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.IsValidated = *abi.ConvertType(out[0], new(bool)).(*bool)
+	outstruct.IsCancelled = *abi.ConvertType(out[1], new(bool)).(*bool)
+	outstruct.TotalFilled = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.TotalSize = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// GetOrderStatus is a free data retrieval call binding the contract method 0x46423aa7.
+//
+// Solidity: function getOrderStatus(bytes32 orderHash) view returns(bool isValidated, bool isCancelled, uint256 totalFilled, uint256 totalSize)
+func (_Openseaseaport *OpenseaseaportSession) GetOrderStatus(orderHash [32]byte) (struct {
+	IsValidated bool
+	IsCancelled bool
+	TotalFilled *big.Int
+	TotalSize   *big.Int
+}, error) {
+	return _Openseaseaport.Contract.GetOrderStatus(&_Openseaseaport.CallOpts, orderHash)
+}
+
+// GetOrderStatus is a free data retrieval call binding the contract method 0x46423aa7.
+//
+// Solidity: function getOrderStatus(bytes32 orderHash) view returns(bool isValidated, bool isCancelled, uint256 totalFilled, uint256 totalSize)
+func (_Openseaseaport *OpenseaseaportCallerSession) GetOrderStatus(orderHash [32]byte) (struct {
+	IsValidated bool
+	IsCancelled bool
+	TotalFilled *big.Int
+	TotalSize   *big.Int
+}, error) {
+	return _Openseaseaport.Contract.GetOrderStatus(&_Openseaseaport.CallOpts, orderHash)
+}
+
+// Information is a free data retrieval call binding the contract method 0xf47b7740.
+//
+// Solidity: function information() view returns(string version, bytes32 domainSeparator, address conduitController)
+func (_Openseaseaport *OpenseaseaportCaller) Information(opts *bind.CallOpts) (struct {
+	Version           string
+	DomainSeparator   [32]byte
+	ConduitController common.Address
+}, error) {
+	var out []interface{}
+	err := _Openseaseaport.contract.Call(opts, &out, "information")
+
+	outstruct := new(struct {
+		Version           string
+		DomainSeparator   [32]byte
+		ConduitController common.Address
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Version = *abi.ConvertType(out[0], new(string)).(*string)
+	outstruct.DomainSeparator = *abi.ConvertType(out[1], new([32]byte)).(*[32]byte)
+	outstruct.ConduitController = *abi.ConvertType(out[2], new(common.Address)).(*common.Address)
+
+	return *outstruct, err
+
+}
+
+// Information is a free data retrieval call binding the contract method 0xf47b7740.
+//
+// Solidity: function information() view returns(string version, bytes32 domainSeparator, address conduitController)
+func (_Openseaseaport *OpenseaseaportSession) Information() (struct {
+	Version           string
+	DomainSeparator   [32]byte
+	ConduitController common.Address
+}, error) {
+	return _Openseaseaport.Contract.Information(&_Openseaseaport.CallOpts)
+}
+
+// Information is a free data retrieval call binding the contract method 0xf47b7740.
+//
+// Solidity: function information() view returns(string version, bytes32 domainSeparator, address conduitController)
+func (_Openseaseaport *OpenseaseaportCallerSession) Information() (struct {
+	Version           string
+	DomainSeparator   [32]byte
+	ConduitController common.Address
+}, error) {
+	return _Openseaseaport.Contract.Information(&_Openseaseaport.CallOpts)
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() pure returns(string contractName)
+func (_Openseaseaport *OpenseaseaportCaller) Name(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _Openseaseaport.contract.Call(opts, &out, "name")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() pure returns(string contractName)
+func (_Openseaseaport *OpenseaseaportSession) Name() (string, error) {
+	return _Openseaseaport.Contract.Name(&_Openseaseaport.CallOpts)
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() pure returns(string contractName)
+func (_Openseaseaport *OpenseaseaportCallerSession) Name() (string, error) {
+	return _Openseaseaport.Contract.Name(&_Openseaseaport.CallOpts)
+}
+
+// Cancel is a paid mutator transaction binding the contract method 0xfd9f1e10.
+//
+// Solidity: function cancel((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256)[] orders) returns(bool cancelled)
+func (_Openseaseaport *OpenseaseaportTransactor) Cancel(opts *bind.TransactOpts, orders []OrderComponents) (*types.Transaction, error) {
+	return _Openseaseaport.contract.Transact(opts, "cancel", orders)
+}
+
+// Cancel is a paid mutator transaction binding the contract method 0xfd9f1e10.
+//
+// Solidity: function cancel((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256)[] orders) returns(bool cancelled)
+func (_Openseaseaport *OpenseaseaportSession) Cancel(orders []OrderComponents) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.Cancel(&_Openseaseaport.TransactOpts, orders)
+}
+
+// Cancel is a paid mutator transaction binding the contract method 0xfd9f1e10.
+//
+// Solidity: function cancel((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256)[] orders) returns(bool cancelled)
+func (_Openseaseaport *OpenseaseaportTransactorSession) Cancel(orders []OrderComponents) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.Cancel(&_Openseaseaport.TransactOpts, orders)
+}
+
+// FulfillAdvancedOrder is a paid mutator transaction binding the contract method 0xe7acab24.
+//
+// Solidity: function fulfillAdvancedOrder(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),uint120,uint120,bytes,bytes) advancedOrder, (uint256,uint8,uint256,uint256,bytes32[])[] criteriaResolvers, bytes32 fulfillerConduitKey, address recipient) payable returns(bool fulfilled)
+func (_Openseaseaport *OpenseaseaportTransactor) FulfillAdvancedOrder(opts *bind.TransactOpts, advancedOrder AdvancedOrder, criteriaResolvers []CriteriaResolver, fulfillerConduitKey [32]byte, recipient common.Address) (*types.Transaction, error) {
+	return _Openseaseaport.contract.Transact(opts, "fulfillAdvancedOrder", advancedOrder, criteriaResolvers, fulfillerConduitKey, recipient)
+}
+
+// FulfillAdvancedOrder is a paid mutator transaction binding the contract method 0xe7acab24.
+//
+// Solidity: function fulfillAdvancedOrder(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),uint120,uint120,bytes,bytes) advancedOrder, (uint256,uint8,uint256,uint256,bytes32[])[] criteriaResolvers, bytes32 fulfillerConduitKey, address recipient) payable returns(bool fulfilled)
+func (_Openseaseaport *OpenseaseaportSession) FulfillAdvancedOrder(advancedOrder AdvancedOrder, criteriaResolvers []CriteriaResolver, fulfillerConduitKey [32]byte, recipient common.Address) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.FulfillAdvancedOrder(&_Openseaseaport.TransactOpts, advancedOrder, criteriaResolvers, fulfillerConduitKey, recipient)
+}
+
+// FulfillAdvancedOrder is a paid mutator transaction binding the contract method 0xe7acab24.
+//
+// Solidity: function fulfillAdvancedOrder(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),uint120,uint120,bytes,bytes) advancedOrder, (uint256,uint8,uint256,uint256,bytes32[])[] criteriaResolvers, bytes32 fulfillerConduitKey, address recipient) payable returns(bool fulfilled)
+func (_Openseaseaport *OpenseaseaportTransactorSession) FulfillAdvancedOrder(advancedOrder AdvancedOrder, criteriaResolvers []CriteriaResolver, fulfillerConduitKey [32]byte, recipient common.Address) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.FulfillAdvancedOrder(&_Openseaseaport.TransactOpts, advancedOrder, criteriaResolvers, fulfillerConduitKey, recipient)
+}
+
+// FulfillAvailableAdvancedOrders is a paid mutator transaction binding the contract method 0x87201b41.
+//
+// Solidity: function fulfillAvailableAdvancedOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),uint120,uint120,bytes,bytes)[] advancedOrders, (uint256,uint8,uint256,uint256,bytes32[])[] criteriaResolvers, (uint256,uint256)[][] offerFulfillments, (uint256,uint256)[][] considerationFulfillments, bytes32 fulfillerConduitKey, address recipient, uint256 maximumFulfilled) payable returns(bool[] availableOrders, ((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportTransactor) FulfillAvailableAdvancedOrders(opts *bind.TransactOpts, advancedOrders []AdvancedOrder, criteriaResolvers []CriteriaResolver, offerFulfillments [][]FulfillmentComponent, considerationFulfillments [][]FulfillmentComponent, fulfillerConduitKey [32]byte, recipient common.Address, maximumFulfilled *big.Int) (*types.Transaction, error) {
+	return _Openseaseaport.contract.Transact(opts, "fulfillAvailableAdvancedOrders", advancedOrders, criteriaResolvers, offerFulfillments, considerationFulfillments, fulfillerConduitKey, recipient, maximumFulfilled)
+}
+
+// FulfillAvailableAdvancedOrders is a paid mutator transaction binding the contract method 0x87201b41.
+//
+// Solidity: function fulfillAvailableAdvancedOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),uint120,uint120,bytes,bytes)[] advancedOrders, (uint256,uint8,uint256,uint256,bytes32[])[] criteriaResolvers, (uint256,uint256)[][] offerFulfillments, (uint256,uint256)[][] considerationFulfillments, bytes32 fulfillerConduitKey, address recipient, uint256 maximumFulfilled) payable returns(bool[] availableOrders, ((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportSession) FulfillAvailableAdvancedOrders(advancedOrders []AdvancedOrder, criteriaResolvers []CriteriaResolver, offerFulfillments [][]FulfillmentComponent, considerationFulfillments [][]FulfillmentComponent, fulfillerConduitKey [32]byte, recipient common.Address, maximumFulfilled *big.Int) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.FulfillAvailableAdvancedOrders(&_Openseaseaport.TransactOpts, advancedOrders, criteriaResolvers, offerFulfillments, considerationFulfillments, fulfillerConduitKey, recipient, maximumFulfilled)
+}
+
+// FulfillAvailableAdvancedOrders is a paid mutator transaction binding the contract method 0x87201b41.
+//
+// Solidity: function fulfillAvailableAdvancedOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),uint120,uint120,bytes,bytes)[] advancedOrders, (uint256,uint8,uint256,uint256,bytes32[])[] criteriaResolvers, (uint256,uint256)[][] offerFulfillments, (uint256,uint256)[][] considerationFulfillments, bytes32 fulfillerConduitKey, address recipient, uint256 maximumFulfilled) payable returns(bool[] availableOrders, ((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportTransactorSession) FulfillAvailableAdvancedOrders(advancedOrders []AdvancedOrder, criteriaResolvers []CriteriaResolver, offerFulfillments [][]FulfillmentComponent, considerationFulfillments [][]FulfillmentComponent, fulfillerConduitKey [32]byte, recipient common.Address, maximumFulfilled *big.Int) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.FulfillAvailableAdvancedOrders(&_Openseaseaport.TransactOpts, advancedOrders, criteriaResolvers, offerFulfillments, considerationFulfillments, fulfillerConduitKey, recipient, maximumFulfilled)
+}
+
+// FulfillAvailableOrders is a paid mutator transaction binding the contract method 0xed98a574.
+//
+// Solidity: function fulfillAvailableOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes)[] orders, (uint256,uint256)[][] offerFulfillments, (uint256,uint256)[][] considerationFulfillments, bytes32 fulfillerConduitKey, uint256 maximumFulfilled) payable returns(bool[] availableOrders, ((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportTransactor) FulfillAvailableOrders(opts *bind.TransactOpts, orders []Order, offerFulfillments [][]FulfillmentComponent, considerationFulfillments [][]FulfillmentComponent, fulfillerConduitKey [32]byte, maximumFulfilled *big.Int) (*types.Transaction, error) {
+	return _Openseaseaport.contract.Transact(opts, "fulfillAvailableOrders", orders, offerFulfillments, considerationFulfillments, fulfillerConduitKey, maximumFulfilled)
+}
+
+// FulfillAvailableOrders is a paid mutator transaction binding the contract method 0xed98a574.
+//
+// Solidity: function fulfillAvailableOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes)[] orders, (uint256,uint256)[][] offerFulfillments, (uint256,uint256)[][] considerationFulfillments, bytes32 fulfillerConduitKey, uint256 maximumFulfilled) payable returns(bool[] availableOrders, ((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportSession) FulfillAvailableOrders(orders []Order, offerFulfillments [][]FulfillmentComponent, considerationFulfillments [][]FulfillmentComponent, fulfillerConduitKey [32]byte, maximumFulfilled *big.Int) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.FulfillAvailableOrders(&_Openseaseaport.TransactOpts, orders, offerFulfillments, considerationFulfillments, fulfillerConduitKey, maximumFulfilled)
+}
+
+// FulfillAvailableOrders is a paid mutator transaction binding the contract method 0xed98a574.
+//
+// Solidity: function fulfillAvailableOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes)[] orders, (uint256,uint256)[][] offerFulfillments, (uint256,uint256)[][] considerationFulfillments, bytes32 fulfillerConduitKey, uint256 maximumFulfilled) payable returns(bool[] availableOrders, ((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportTransactorSession) FulfillAvailableOrders(orders []Order, offerFulfillments [][]FulfillmentComponent, considerationFulfillments [][]FulfillmentComponent, fulfillerConduitKey [32]byte, maximumFulfilled *big.Int) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.FulfillAvailableOrders(&_Openseaseaport.TransactOpts, orders, offerFulfillments, considerationFulfillments, fulfillerConduitKey, maximumFulfilled)
+}
+
+// FulfillBasicOrder is a paid mutator transaction binding the contract method 0xfb0f3ee1.
+//
+// Solidity: function fulfillBasicOrder((address,uint256,uint256,address,address,address,uint256,uint256,uint8,uint256,uint256,bytes32,uint256,bytes32,bytes32,uint256,(uint256,address)[],bytes) parameters) payable returns(bool fulfilled)
+func (_Openseaseaport *OpenseaseaportTransactor) FulfillBasicOrder(opts *bind.TransactOpts, parameters BasicOrderParameters) (*types.Transaction, error) {
+	return _Openseaseaport.contract.Transact(opts, "fulfillBasicOrder", parameters)
+}
+
+// FulfillBasicOrder is a paid mutator transaction binding the contract method 0xfb0f3ee1.
+//
+// Solidity: function fulfillBasicOrder((address,uint256,uint256,address,address,address,uint256,uint256,uint8,uint256,uint256,bytes32,uint256,bytes32,bytes32,uint256,(uint256,address)[],bytes) parameters) payable returns(bool fulfilled)
+func (_Openseaseaport *OpenseaseaportSession) FulfillBasicOrder(parameters BasicOrderParameters) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.FulfillBasicOrder(&_Openseaseaport.TransactOpts, parameters)
+}
+
+// FulfillBasicOrder is a paid mutator transaction binding the contract method 0xfb0f3ee1.
+//
+// Solidity: function fulfillBasicOrder((address,uint256,uint256,address,address,address,uint256,uint256,uint8,uint256,uint256,bytes32,uint256,bytes32,bytes32,uint256,(uint256,address)[],bytes) parameters) payable returns(bool fulfilled)
+func (_Openseaseaport *OpenseaseaportTransactorSession) FulfillBasicOrder(parameters BasicOrderParameters) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.FulfillBasicOrder(&_Openseaseaport.TransactOpts, parameters)
+}
+
+// FulfillOrder is a paid mutator transaction binding the contract method 0xb3a34c4c.
+//
+// Solidity: function fulfillOrder(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes) order, bytes32 fulfillerConduitKey) payable returns(bool fulfilled)
+func (_Openseaseaport *OpenseaseaportTransactor) FulfillOrder(opts *bind.TransactOpts, order Order, fulfillerConduitKey [32]byte) (*types.Transaction, error) {
+	return _Openseaseaport.contract.Transact(opts, "fulfillOrder", order, fulfillerConduitKey)
+}
+
+// FulfillOrder is a paid mutator transaction binding the contract method 0xb3a34c4c.
+//
+// Solidity: function fulfillOrder(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes) order, bytes32 fulfillerConduitKey) payable returns(bool fulfilled)
+func (_Openseaseaport *OpenseaseaportSession) FulfillOrder(order Order, fulfillerConduitKey [32]byte) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.FulfillOrder(&_Openseaseaport.TransactOpts, order, fulfillerConduitKey)
+}
+
+// FulfillOrder is a paid mutator transaction binding the contract method 0xb3a34c4c.
+//
+// Solidity: function fulfillOrder(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes) order, bytes32 fulfillerConduitKey) payable returns(bool fulfilled)
+func (_Openseaseaport *OpenseaseaportTransactorSession) FulfillOrder(order Order, fulfillerConduitKey [32]byte) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.FulfillOrder(&_Openseaseaport.TransactOpts, order, fulfillerConduitKey)
+}
+
+// IncrementCounter is a paid mutator transaction binding the contract method 0x5b34b966.
+//
+// Solidity: function incrementCounter() returns(uint256 newCounter)
+func (_Openseaseaport *OpenseaseaportTransactor) IncrementCounter(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Openseaseaport.contract.Transact(opts, "incrementCounter")
+}
+
+// IncrementCounter is a paid mutator transaction binding the contract method 0x5b34b966.
+//
+// Solidity: function incrementCounter() returns(uint256 newCounter)
+func (_Openseaseaport *OpenseaseaportSession) IncrementCounter() (*types.Transaction, error) {
+	return _Openseaseaport.Contract.IncrementCounter(&_Openseaseaport.TransactOpts)
+}
+
+// IncrementCounter is a paid mutator transaction binding the contract method 0x5b34b966.
+//
+// Solidity: function incrementCounter() returns(uint256 newCounter)
+func (_Openseaseaport *OpenseaseaportTransactorSession) IncrementCounter() (*types.Transaction, error) {
+	return _Openseaseaport.Contract.IncrementCounter(&_Openseaseaport.TransactOpts)
+}
+
+// MatchAdvancedOrders is a paid mutator transaction binding the contract method 0x55944a42.
+//
+// Solidity: function matchAdvancedOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),uint120,uint120,bytes,bytes)[] advancedOrders, (uint256,uint8,uint256,uint256,bytes32[])[] criteriaResolvers, ((uint256,uint256)[],(uint256,uint256)[])[] fulfillments) payable returns(((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportTransactor) MatchAdvancedOrders(opts *bind.TransactOpts, advancedOrders []AdvancedOrder, criteriaResolvers []CriteriaResolver, fulfillments []Fulfillment) (*types.Transaction, error) {
+	return _Openseaseaport.contract.Transact(opts, "matchAdvancedOrders", advancedOrders, criteriaResolvers, fulfillments)
+}
+
+// MatchAdvancedOrders is a paid mutator transaction binding the contract method 0x55944a42.
+//
+// Solidity: function matchAdvancedOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),uint120,uint120,bytes,bytes)[] advancedOrders, (uint256,uint8,uint256,uint256,bytes32[])[] criteriaResolvers, ((uint256,uint256)[],(uint256,uint256)[])[] fulfillments) payable returns(((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportSession) MatchAdvancedOrders(advancedOrders []AdvancedOrder, criteriaResolvers []CriteriaResolver, fulfillments []Fulfillment) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.MatchAdvancedOrders(&_Openseaseaport.TransactOpts, advancedOrders, criteriaResolvers, fulfillments)
+}
+
+// MatchAdvancedOrders is a paid mutator transaction binding the contract method 0x55944a42.
+//
+// Solidity: function matchAdvancedOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),uint120,uint120,bytes,bytes)[] advancedOrders, (uint256,uint8,uint256,uint256,bytes32[])[] criteriaResolvers, ((uint256,uint256)[],(uint256,uint256)[])[] fulfillments) payable returns(((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportTransactorSession) MatchAdvancedOrders(advancedOrders []AdvancedOrder, criteriaResolvers []CriteriaResolver, fulfillments []Fulfillment) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.MatchAdvancedOrders(&_Openseaseaport.TransactOpts, advancedOrders, criteriaResolvers, fulfillments)
+}
+
+// MatchOrders is a paid mutator transaction binding the contract method 0xa8174404.
+//
+// Solidity: function matchOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes)[] orders, ((uint256,uint256)[],(uint256,uint256)[])[] fulfillments) payable returns(((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportTransactor) MatchOrders(opts *bind.TransactOpts, orders []Order, fulfillments []Fulfillment) (*types.Transaction, error) {
+	return _Openseaseaport.contract.Transact(opts, "matchOrders", orders, fulfillments)
+}
+
+// MatchOrders is a paid mutator transaction binding the contract method 0xa8174404.
+//
+// Solidity: function matchOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes)[] orders, ((uint256,uint256)[],(uint256,uint256)[])[] fulfillments) payable returns(((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportSession) MatchOrders(orders []Order, fulfillments []Fulfillment) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.MatchOrders(&_Openseaseaport.TransactOpts, orders, fulfillments)
+}
+
+// MatchOrders is a paid mutator transaction binding the contract method 0xa8174404.
+//
+// Solidity: function matchOrders(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes)[] orders, ((uint256,uint256)[],(uint256,uint256)[])[] fulfillments) payable returns(((uint8,address,uint256,uint256,address),address,bytes32)[] executions)
+func (_Openseaseaport *OpenseaseaportTransactorSession) MatchOrders(orders []Order, fulfillments []Fulfillment) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.MatchOrders(&_Openseaseaport.TransactOpts, orders, fulfillments)
+}
+
+// Validate is a paid mutator transaction binding the contract method 0x88147732.
+//
+// Solidity: function validate(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes)[] orders) returns(bool validated)
+func (_Openseaseaport *OpenseaseaportTransactor) Validate(opts *bind.TransactOpts, orders []Order) (*types.Transaction, error) {
+	return _Openseaseaport.contract.Transact(opts, "validate", orders)
+}
+
+// Validate is a paid mutator transaction binding the contract method 0x88147732.
+//
+// Solidity: function validate(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes)[] orders) returns(bool validated)
+func (_Openseaseaport *OpenseaseaportSession) Validate(orders []Order) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.Validate(&_Openseaseaport.TransactOpts, orders)
+}
+
+// Validate is a paid mutator transaction binding the contract method 0x88147732.
+//
+// Solidity: function validate(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),bytes)[] orders) returns(bool validated)
+func (_Openseaseaport *OpenseaseaportTransactorSession) Validate(orders []Order) (*types.Transaction, error) {
+	return _Openseaseaport.Contract.Validate(&_Openseaseaport.TransactOpts, orders)
+}
+
+// OpenseaseaportCounterIncrementedIterator is returned from FilterCounterIncremented and is used to iterate over the raw logs and unpacked data for CounterIncremented events raised by the Openseaseaport contract.
+type OpenseaseaportCounterIncrementedIterator struct {
+	Event *OpenseaseaportCounterIncremented // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OpenseaseaportCounterIncrementedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OpenseaseaportCounterIncremented)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OpenseaseaportCounterIncremented)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OpenseaseaportCounterIncrementedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OpenseaseaportCounterIncrementedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OpenseaseaportCounterIncremented represents a CounterIncremented event raised by the Openseaseaport contract.
+type OpenseaseaportCounterIncremented struct {
+	NewCounter *big.Int
+	Offerer    common.Address
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterCounterIncremented is a free log retrieval operation binding the contract event 0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f.
+//
+// Solidity: event CounterIncremented(uint256 newCounter, address indexed offerer)
+func (_Openseaseaport *OpenseaseaportFilterer) FilterCounterIncremented(opts *bind.FilterOpts, offerer []common.Address) (*OpenseaseaportCounterIncrementedIterator, error) {
+
+	var offererRule []interface{}
+	for _, offererItem := range offerer {
+		offererRule = append(offererRule, offererItem)
+	}
+
+	logs, sub, err := _Openseaseaport.contract.FilterLogs(opts, "CounterIncremented", offererRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OpenseaseaportCounterIncrementedIterator{contract: _Openseaseaport.contract, event: "CounterIncremented", logs: logs, sub: sub}, nil
+}
+
+// WatchCounterIncremented is a free log subscription operation binding the contract event 0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f.
+//
+// Solidity: event CounterIncremented(uint256 newCounter, address indexed offerer)
+func (_Openseaseaport *OpenseaseaportFilterer) WatchCounterIncremented(opts *bind.WatchOpts, sink chan<- *OpenseaseaportCounterIncremented, offerer []common.Address) (event.Subscription, error) {
+
+	var offererRule []interface{}
+	for _, offererItem := range offerer {
+		offererRule = append(offererRule, offererItem)
+	}
+
+	logs, sub, err := _Openseaseaport.contract.WatchLogs(opts, "CounterIncremented", offererRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OpenseaseaportCounterIncremented)
+				if err := _Openseaseaport.contract.UnpackLog(event, "CounterIncremented", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseCounterIncremented is a log parse operation binding the contract event 0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f.
+//
+// Solidity: event CounterIncremented(uint256 newCounter, address indexed offerer)
+func (_Openseaseaport *OpenseaseaportFilterer) ParseCounterIncremented(log types.Log) (*OpenseaseaportCounterIncremented, error) {
+	event := new(OpenseaseaportCounterIncremented)
+	if err := _Openseaseaport.contract.UnpackLog(event, "CounterIncremented", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// OpenseaseaportOrderCancelledIterator is returned from FilterOrderCancelled and is used to iterate over the raw logs and unpacked data for OrderCancelled events raised by the Openseaseaport contract.
+type OpenseaseaportOrderCancelledIterator struct {
+	Event *OpenseaseaportOrderCancelled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OpenseaseaportOrderCancelledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OpenseaseaportOrderCancelled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OpenseaseaportOrderCancelled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OpenseaseaportOrderCancelledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OpenseaseaportOrderCancelledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OpenseaseaportOrderCancelled represents a OrderCancelled event raised by the Openseaseaport contract.
+type OpenseaseaportOrderCancelled struct {
+	OrderHash [32]byte
+	Offerer   common.Address
+	Zone      common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterOrderCancelled is a free log retrieval operation binding the contract event 0x6bacc01dbe442496068f7d234edd811f1a5f833243e0aec824f86ab861f3c90d.
+//
+// Solidity: event OrderCancelled(bytes32 orderHash, address indexed offerer, address indexed zone)
+func (_Openseaseaport *OpenseaseaportFilterer) FilterOrderCancelled(opts *bind.FilterOpts, offerer []common.Address, zone []common.Address) (*OpenseaseaportOrderCancelledIterator, error) {
+
+	var offererRule []interface{}
+	for _, offererItem := range offerer {
+		offererRule = append(offererRule, offererItem)
+	}
+	var zoneRule []interface{}
+	for _, zoneItem := range zone {
+		zoneRule = append(zoneRule, zoneItem)
+	}
+
+	logs, sub, err := _Openseaseaport.contract.FilterLogs(opts, "OrderCancelled", offererRule, zoneRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OpenseaseaportOrderCancelledIterator{contract: _Openseaseaport.contract, event: "OrderCancelled", logs: logs, sub: sub}, nil
+}
+
+// WatchOrderCancelled is a free log subscription operation binding the contract event 0x6bacc01dbe442496068f7d234edd811f1a5f833243e0aec824f86ab861f3c90d.
+//
+// Solidity: event OrderCancelled(bytes32 orderHash, address indexed offerer, address indexed zone)
+func (_Openseaseaport *OpenseaseaportFilterer) WatchOrderCancelled(opts *bind.WatchOpts, sink chan<- *OpenseaseaportOrderCancelled, offerer []common.Address, zone []common.Address) (event.Subscription, error) {
+
+	var offererRule []interface{}
+	for _, offererItem := range offerer {
+		offererRule = append(offererRule, offererItem)
+	}
+	var zoneRule []interface{}
+	for _, zoneItem := range zone {
+		zoneRule = append(zoneRule, zoneItem)
+	}
+
+	logs, sub, err := _Openseaseaport.contract.WatchLogs(opts, "OrderCancelled", offererRule, zoneRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OpenseaseaportOrderCancelled)
+				if err := _Openseaseaport.contract.UnpackLog(event, "OrderCancelled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOrderCancelled is a log parse operation binding the contract event 0x6bacc01dbe442496068f7d234edd811f1a5f833243e0aec824f86ab861f3c90d.
+//
+// Solidity: event OrderCancelled(bytes32 orderHash, address indexed offerer, address indexed zone)
+func (_Openseaseaport *OpenseaseaportFilterer) ParseOrderCancelled(log types.Log) (*OpenseaseaportOrderCancelled, error) {
+	event := new(OpenseaseaportOrderCancelled)
+	if err := _Openseaseaport.contract.UnpackLog(event, "OrderCancelled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// OpenseaseaportOrderFulfilledIterator is returned from FilterOrderFulfilled and is used to iterate over the raw logs and unpacked data for OrderFulfilled events raised by the Openseaseaport contract.
+type OpenseaseaportOrderFulfilledIterator struct {
+	Event *OpenseaseaportOrderFulfilled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OpenseaseaportOrderFulfilledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OpenseaseaportOrderFulfilled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OpenseaseaportOrderFulfilled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OpenseaseaportOrderFulfilledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OpenseaseaportOrderFulfilledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OpenseaseaportOrderFulfilled represents a OrderFulfilled event raised by the Openseaseaport contract.
+type OpenseaseaportOrderFulfilled struct {
+	OrderHash     [32]byte
+	Offerer       common.Address
+	Zone          common.Address
+	Recipient     common.Address
+	Offer         []SpentItem
+	Consideration []ReceivedItem
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOrderFulfilled is a free log retrieval operation binding the contract event 0x9d9af8e38d66c62e2c12f0225249fd9d721c54b83f48d9352c97c6cacdcb6f31.
+//
+// Solidity: event OrderFulfilled(bytes32 orderHash, address indexed offerer, address indexed zone, address recipient, (uint8,address,uint256,uint256)[] offer, (uint8,address,uint256,uint256,address)[] consideration)
+func (_Openseaseaport *OpenseaseaportFilterer) FilterOrderFulfilled(opts *bind.FilterOpts, offerer []common.Address, zone []common.Address) (*OpenseaseaportOrderFulfilledIterator, error) {
+
+	var offererRule []interface{}
+	for _, offererItem := range offerer {
+		offererRule = append(offererRule, offererItem)
+	}
+	var zoneRule []interface{}
+	for _, zoneItem := range zone {
+		zoneRule = append(zoneRule, zoneItem)
+	}
+
+	logs, sub, err := _Openseaseaport.contract.FilterLogs(opts, "OrderFulfilled", offererRule, zoneRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OpenseaseaportOrderFulfilledIterator{contract: _Openseaseaport.contract, event: "OrderFulfilled", logs: logs, sub: sub}, nil
+}
+
+// WatchOrderFulfilled is a free log subscription operation binding the contract event 0x9d9af8e38d66c62e2c12f0225249fd9d721c54b83f48d9352c97c6cacdcb6f31.
+//
+// Solidity: event OrderFulfilled(bytes32 orderHash, address indexed offerer, address indexed zone, address recipient, (uint8,address,uint256,uint256)[] offer, (uint8,address,uint256,uint256,address)[] consideration)
+func (_Openseaseaport *OpenseaseaportFilterer) WatchOrderFulfilled(opts *bind.WatchOpts, sink chan<- *OpenseaseaportOrderFulfilled, offerer []common.Address, zone []common.Address) (event.Subscription, error) {
+
+	var offererRule []interface{}
+	for _, offererItem := range offerer {
+		offererRule = append(offererRule, offererItem)
+	}
+	var zoneRule []interface{}
+	for _, zoneItem := range zone {
+		zoneRule = append(zoneRule, zoneItem)
+	}
+
+	logs, sub, err := _Openseaseaport.contract.WatchLogs(opts, "OrderFulfilled", offererRule, zoneRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OpenseaseaportOrderFulfilled)
+				if err := _Openseaseaport.contract.UnpackLog(event, "OrderFulfilled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOrderFulfilled is a log parse operation binding the contract event 0x9d9af8e38d66c62e2c12f0225249fd9d721c54b83f48d9352c97c6cacdcb6f31.
+//
+// Solidity: event OrderFulfilled(bytes32 orderHash, address indexed offerer, address indexed zone, address recipient, (uint8,address,uint256,uint256)[] offer, (uint8,address,uint256,uint256,address)[] consideration)
+func (_Openseaseaport *OpenseaseaportFilterer) ParseOrderFulfilled(log types.Log) (*OpenseaseaportOrderFulfilled, error) {
+	event := new(OpenseaseaportOrderFulfilled)
+	if err := _Openseaseaport.contract.UnpackLog(event, "OrderFulfilled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// OpenseaseaportOrderValidatedIterator is returned from FilterOrderValidated and is used to iterate over the raw logs and unpacked data for OrderValidated events raised by the Openseaseaport contract.
+type OpenseaseaportOrderValidatedIterator struct {
+	Event *OpenseaseaportOrderValidated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OpenseaseaportOrderValidatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OpenseaseaportOrderValidated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OpenseaseaportOrderValidated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OpenseaseaportOrderValidatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OpenseaseaportOrderValidatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OpenseaseaportOrderValidated represents a OrderValidated event raised by the Openseaseaport contract.
+type OpenseaseaportOrderValidated struct {
+	OrderHash [32]byte
+	Offerer   common.Address
+	Zone      common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterOrderValidated is a free log retrieval operation binding the contract event 0xfde361574a066b44b3b5fe98a87108b7565e327327954c4faeea56a4e6491a0a.
+//
+// Solidity: event OrderValidated(bytes32 orderHash, address indexed offerer, address indexed zone)
+func (_Openseaseaport *OpenseaseaportFilterer) FilterOrderValidated(opts *bind.FilterOpts, offerer []common.Address, zone []common.Address) (*OpenseaseaportOrderValidatedIterator, error) {
+
+	var offererRule []interface{}
+	for _, offererItem := range offerer {
+		offererRule = append(offererRule, offererItem)
+	}
+	var zoneRule []interface{}
+	for _, zoneItem := range zone {
+		zoneRule = append(zoneRule, zoneItem)
+	}
+
+	logs, sub, err := _Openseaseaport.contract.FilterLogs(opts, "OrderValidated", offererRule, zoneRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OpenseaseaportOrderValidatedIterator{contract: _Openseaseaport.contract, event: "OrderValidated", logs: logs, sub: sub}, nil
+}
+
+// WatchOrderValidated is a free log subscription operation binding the contract event 0xfde361574a066b44b3b5fe98a87108b7565e327327954c4faeea56a4e6491a0a.
+//
+// Solidity: event OrderValidated(bytes32 orderHash, address indexed offerer, address indexed zone)
+func (_Openseaseaport *OpenseaseaportFilterer) WatchOrderValidated(opts *bind.WatchOpts, sink chan<- *OpenseaseaportOrderValidated, offerer []common.Address, zone []common.Address) (event.Subscription, error) {
+
+	var offererRule []interface{}
+	for _, offererItem := range offerer {
+		offererRule = append(offererRule, offererItem)
+	}
+	var zoneRule []interface{}
+	for _, zoneItem := range zone {
+		zoneRule = append(zoneRule, zoneItem)
+	}
+
+	logs, sub, err := _Openseaseaport.contract.WatchLogs(opts, "OrderValidated", offererRule, zoneRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OpenseaseaportOrderValidated)
+				if err := _Openseaseaport.contract.UnpackLog(event, "OrderValidated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOrderValidated is a log parse operation binding the contract event 0xfde361574a066b44b3b5fe98a87108b7565e327327954c4faeea56a4e6491a0a.
+//
+// Solidity: event OrderValidated(bytes32 orderHash, address indexed offerer, address indexed zone)
+func (_Openseaseaport *OpenseaseaportFilterer) ParseOrderValidated(log types.Log) (*OpenseaseaportOrderValidated, error) {
+	event := new(OpenseaseaportOrderValidated)
+	if err := _Openseaseaport.contract.UnpackLog(event, "OrderValidated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/pkg/dia/nft/nftTrade-scrapers/openseaSeaport.go
+++ b/pkg/dia/nft/nftTrade-scrapers/openseaSeaport.go
@@ -1,0 +1,923 @@
+package nfttradescrapers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/diadata-org/diadata/config/nftContracts/erc20"
+	"github.com/diadata-org/diadata/config/nftContracts/erc721"
+	"github.com/diadata-org/diadata/config/nftContracts/openseaseaport"
+	"github.com/diadata-org/diadata/pkg/dia"
+	"github.com/diadata-org/diadata/pkg/dia/helpers/ethhelper"
+	models "github.com/diadata-org/diadata/pkg/model"
+	"github.com/diadata-org/diadata/pkg/utils"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/jackc/pgx/v4"
+	"github.com/shopspring/decimal"
+)
+
+const (
+	// we assume all of the NFTs traded on OpenSea are ERC721(1155 is an extension of it)
+	openSeaSeaportNFTContractType = "ERC721"
+)
+
+type OpenSeaSeaportScraperConfig struct {
+	// opensea's exchange contract address on connected blockchain network
+	ContractAddr string `json:"contract_addr"`
+
+	// indicates the batch size during read the filtered events
+	BatchSize int `json:"batch_size"`
+
+	// wait for a while between batch retrieval of filtered events
+	WaitPeriod time.Duration `json:"wait_per_batch"`
+
+	// it enables read contract data from the event's block
+	// height instead of the last state
+	FollowDist int `json:"following_distance_blocks"`
+
+	// if set it will read erc721 attributes at the currently
+	// processing block
+	UseArchiveNode bool `json:"use_archive_node_fetaures"`
+
+	// indicates the number of retries to scrape the target
+	// in case of an unexpected error
+	MaxRetry int `json:"max_retry"`
+
+	// if true the scraper will skip the currently scraping
+	// block when retries reach to the value MaxRetry
+	SkipOnErr bool `json:"skip_on_error"`
+
+	// it limits read bytes for NFT's metadata from external url
+	MaxMetadataSize int `json:"max_metadata_size"`
+
+	// it limits duration of read for NFT's metadata from external url
+	MetadataTimeout time.Duration `json:"metadata_timeout"`
+}
+
+type OpenSeaSeaportScraperState struct {
+	// last block number has been processed
+	LastBlockNum uint64 `json:"last_block_num"`
+
+	// last transaction index in the block(curr) has been processed
+	LastTxIndex uint `json:"last_tx_index"`
+
+	// holds the latest error message that occurred while scraping
+	LastErr string `json:"last_error"`
+
+	// indicates the number of consecutive error, reset on any successful operation
+	ErrCounter int `json:"count_of_error"`
+}
+
+type OpenSeaSeaportScraper struct {
+	tradeScraper TradeScraper
+
+	mu    sync.Mutex
+	conf  *OpenSeaSeaportScraperConfig
+	state *OpenSeaSeaportScraperState
+}
+
+var (
+	errOpenSeaSeaportShutdownRequest = errors.New("shutdown requested")
+
+	// default values are valid for the first run which is it saves
+	// these configs to the DB
+	defOpenSeaSeaportConf = OpenSeaSeaportScraperConfig{
+		ContractAddr:    "0x00000000006c3852cbEf3e08E8dF289169EdE581", // Seaport
+		BatchSize:       100,
+		WaitPeriod:      1,
+		FollowDist:      10,
+		UseArchiveNode:  false,
+		MaxRetry:        5,
+		SkipOnErr:       true,
+		MaxMetadataSize: 50 * 1024,
+		MetadataTimeout: 30 * time.Second,
+	}
+
+	// Seaport 1.1 contract has been deployed on the mainnet at
+	// block num 14946474, so scraper starts from this block.
+	defOpenSeaSeaportState = &OpenSeaSeaportScraperState{LastBlockNum: 14946474}
+
+	// This string is the identifier of the scraper in conf and state fields in postgres.
+	OpenSeaSeaport = "openseaSeaport"
+
+	openSeaSeaportABI abi.ABI
+
+	assetCacheOpenseaSeaport = make(map[string]dia.Asset)
+)
+
+func init() {
+	var err error
+
+	openSeaSeaportABI, err = abi.JSON(strings.NewReader(openseaseaport.OpenseaseaportMetaData.ABI))
+	if err != nil {
+		panic(err)
+	}
+
+	erc20ABI, err = abi.JSON(strings.NewReader(erc20.ERC20ABI))
+	if err != nil {
+		panic(err)
+	}
+
+	erc721ABI, err = abi.JSON(strings.NewReader(erc721.ERC721ABI))
+	if err != nil {
+		panic(err)
+	}
+
+	OpenSeaSeaport = utils.Getenv("SCRAPER_NAME_STATE", "openseaSeaport")
+
+	// If scraper state is not set yet, start from this block
+	initBlockNumString := utils.Getenv("LAST_BLOCK_NUM", "14946474")
+	initBlockNum, err := strconv.ParseInt(initBlockNumString, 10, 64)
+	if err != nil {
+		log.Error("parse timeFinal: ", err)
+	}
+
+	defOpenSeaSeaportState.LastBlockNum = uint64(initBlockNum)
+}
+
+func NewOpenSeaSeaportScraper(rdb *models.RelDB) *OpenSeaSeaportScraper {
+	ctx := context.Background()
+
+	eth, err := ethclient.Dial(utils.Getenv("ETH_URI_REST", ""))
+	if err != nil {
+		log.Error("Error connecting Eth Client")
+	}
+
+	s := &OpenSeaSeaportScraper{
+		conf:  &OpenSeaSeaportScraperConfig{},
+		state: &OpenSeaSeaportScraperState{},
+		tradeScraper: TradeScraper{
+			shutdown:      make(chan nothing),
+			shutdownDone:  make(chan nothing),
+			datastore:     rdb,
+			chanTrade:     make(chan dia.NFTTrade),
+			source:        "OpenSeaSeaport",
+			ethConnection: eth,
+		},
+	}
+
+	if err := s.initScraper(ctx); err != nil {
+		log.Errorf("opensea seaport scraper could not be initialized: %s", err.Error())
+
+		return nil
+	}
+
+	log.Infof("scraper %s starts at block: %d", OpenSeaSeaport, s.state.LastBlockNum)
+
+	go s.mainLoop()
+
+	return s
+}
+
+// init scraper
+// if there are no values stored previously, use defaults and store them
+func (s *OpenSeaSeaportScraper) initScraper(ctx context.Context) error {
+	if err := s.loadConfig(ctx); err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			log.Errorf("unable to read scraper config from rdb: %s", err.Error())
+
+			return err
+		}
+
+		// use & store defaults if there is no record in the scraper table
+
+		defConf := defOpenSeaSeaportConf // copy
+		s.conf = &defConf
+		if err := s.tradeScraper.datastore.SetScraperConfig(ctx, OpenSeaSeaport, s.conf); err != nil {
+			log.Errorf("unable to store scraper config on rdb: %s", err.Error())
+
+			return err
+		}
+
+		defState := *defOpenSeaSeaportState // copy
+		s.state = &defState
+		if err := s.tradeScraper.datastore.SetScraperState(ctx, OpenSeaSeaport, s.state); err != nil {
+			log.Errorf("unable to store scraper state on rdb: %s", err.Error())
+
+			return err
+		}
+
+		return nil
+	}
+
+	return s.loadState(ctx)
+}
+
+func (s *OpenSeaSeaportScraper) loadConfig(ctx context.Context) error {
+	return s.tradeScraper.datastore.GetScraperConfig(ctx, OpenSeaSeaport, s.conf)
+}
+
+func (s *OpenSeaSeaportScraper) loadState(ctx context.Context) error {
+	return s.tradeScraper.datastore.GetScraperState(ctx, OpenSeaSeaport, s.state)
+}
+
+func (s *OpenSeaSeaportScraper) storeState(ctx context.Context) error {
+	return s.tradeScraper.datastore.SetScraperState(ctx, OpenSeaSeaport, s.state)
+}
+
+func (s *OpenSeaSeaportScraper) mainLoop() {
+	defer func() {
+		s.tradeScraper.closed = true
+
+		close(s.tradeScraper.chanTrade)
+		close(s.tradeScraper.shutdownDone)
+	}()
+
+	c := defOpenSeaSeaportConf
+	s.conf = &c
+
+	log.Infof("opensea scraper has been started (batch: %d, period: %s)", s.conf.BatchSize, s.conf.WaitPeriod.String())
+
+	for stop := false; !stop; {
+		log.Info("---------------------------STARTING NEW BATCH FETCH----------------------")
+		if err := s.FetchTrades(); err != nil {
+			if errors.Is(err, errOpenSeaSeaportShutdownRequest) {
+				stop = true
+				continue
+			}
+		}
+
+		log.Debugf("wait for %s", s.conf.WaitPeriod)
+
+		select {
+		case <-time.After(s.conf.WaitPeriod):
+		case <-s.tradeScraper.shutdown:
+			stop = true
+		}
+	}
+}
+
+// FetchTrades searches for trades on-chain by the next block range
+func (s *OpenSeaSeaportScraper) FetchTrades() error {
+	var err error
+
+	// TODO: make FetchTrades context-aware
+	ctx := context.Background()
+
+	// it must be run once at a time
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// read config
+	if err = s.loadConfig(ctx); err != nil {
+		log.Warnf("unable to load scraper config: %s", err.Error())
+
+		return err
+	}
+
+	// read state
+	if err = s.loadState(ctx); err != nil {
+		log.Warnf("unable to load scraper state: %s", err.Error())
+
+		return err
+	}
+
+	c := defOpenSeaSeaportConf
+	s.conf = &c
+
+	log.Infof("fetching opensea trade transactions from block %d(+%d)", s.state.LastBlockNum, s.conf.BatchSize)
+
+	// fetch trade transactions
+	res, err := utils.EthFilterTXs(ctx, s.tradeScraper.ethConnection, utils.EthTxFilterCriteria{
+		StartBlockNum:      s.state.LastBlockNum,
+		StartTxIndex:       s.state.LastTxIndex,
+		LimitBlocks:        s.conf.BatchSize,
+		BehindHighestBlock: s.conf.FollowDist,
+		EvAddrs:            []common.Address{common.HexToAddress(s.conf.ContractAddr)},
+		Events:             []common.Hash{openSeaSeaportABI.Events["OrderFulfilled"].ID},
+	})
+
+	if err != nil {
+		log.Warnf("unable to filter opensea trades: %s", err.Error())
+
+		return err
+	}
+
+	log.Infof("found %d trade(logs: %d) transactions in %d blocks(from %d [tx index offset: %d] to %d, sync: %t[stay behind: -%d]), exploring details...", res.NumTXs, res.NumLogs, res.NumBlocks, s.state.LastBlockNum, s.state.LastTxIndex, res.LastBlockNum, res.Synced, s.conf.FollowDist)
+
+	numTrades := 0
+
+	// process trade transactions
+	for _, tx := range res.TXs {
+		s.state.LastBlockNum = tx.BlockNum
+		s.state.LastTxIndex = tx.TXIndex
+		s.state.LastErr = ""
+		log.Info("current state.ErrCounter: ", s.state.ErrCounter)
+
+		skipped, err := s.processTx(ctx, tx)
+		if err != nil {
+			s.state.ErrCounter++
+
+			if s.state.ErrCounter <= s.conf.MaxRetry {
+				s.state.LastErr = fmt.Sprintf("unable to process trade transaction(%s): %s", tx.TXHash.Hex(), err.Error())
+				log.Error(s.state.LastErr)
+				// store state
+				if err := s.storeState(ctx); err != nil {
+					log.Warnf("unable to store scraper state: %s", err.Error())
+
+					return err
+				}
+
+				return err
+			}
+
+			log.Warnf("SKIPPING PERMANENTLY! block: %d, tx index: %d - error: %s", s.state.LastBlockNum, s.state.LastTxIndex, err.Error())
+		}
+
+		if !skipped {
+			numTrades++
+		}
+
+		// reset consecutive error counter
+		s.state.ErrCounter = 0
+
+		// move next
+		s.state.LastTxIndex = tx.TXIndex + 1
+
+		// store state
+		if err := s.storeState(ctx); err != nil {
+			log.Warnf("unable to store scraper state: %s", err.Error())
+
+			return err
+		}
+	}
+
+	s.state.LastBlockNum = res.LastBlockNum + 1
+	s.state.LastTxIndex = 0
+
+	if err := s.storeState(ctx); err != nil {
+		log.Warnf("unable to store scraper state: %s", err.Error())
+
+		return err
+	}
+
+	log.Infof("processed %d trades", numTrades)
+
+	return nil
+}
+
+func (s *OpenSeaSeaportScraper) processTx(ctx context.Context, tx *utils.EthFilteredTx) (bool, error) {
+	log.Tracef("process tx -> block: %d, tx index: %d, tx hash: %s", tx.BlockNum, tx.TXIndex, tx.TXHash.Hex())
+
+	// skip if the transaction has multiple OrdersMatched logs
+	if len(tx.Logs) != 1 {
+		return true, nil
+	}
+
+	marketContractNew, err := openseaseaport.NewOpenseaseaport(tx.Logs[0].Address, s.tradeScraper.ethConnection)
+	if err != nil {
+		log.Errorf("unable to make new market contract for address: %s", tx.Logs[0].Address.Hex())
+
+		return false, err
+	}
+
+	ev, err := marketContractNew.ParseOrderFulfilled(tx.Logs[0])
+	if err != nil {
+		log.Errorf("unable to decode opensea seaport OrderFulfilled event(tx: %s, logIndex: %d) (SKIPPED!): %s", tx.TXHash, tx.Logs[0].Index, err.Error())
+
+		return true, nil // skip
+	}
+
+	txData, pending, err := s.tradeScraper.ethConnection.TransactionByHash(ctx, tx.TXHash)
+	if err != nil {
+		log.Errorf("unable to read transaction(%s): %s", tx.TXHash, err.Error())
+
+		return false, err
+	}
+	if pending {
+		err = fmt.Errorf("transaction(%s) status error: pending=true", tx.TXHash)
+		log.Error(err.Error())
+
+		return false, err
+	}
+
+	receipt, err := s.tradeScraper.ethConnection.TransactionReceipt(ctx, tx.TXHash)
+	if err != nil {
+		log.Errorf("unable to read transaction(%s) receipt: %s", tx.TXHash, err.Error())
+
+		return false, err
+	}
+
+	currSymbol := "ETH"
+	currAddr := common.Address{}
+	currDecimals := 18
+
+	// if an ERC20 token used for the trade
+	if new(big.Int).Cmp(txData.Value()) == 0 {
+		var tokenTransfers []*erc20Transfer
+		tokenTransfers, err = s.findERC20Transfers(ctx, receipt, big.NewInt(0))
+		if err != nil {
+			log.Errorf("unable to find erc20 transfers for transaction(%s): %s", tx.TXHash, err.Error())
+
+			return false, err
+		}
+
+		if len(tokenTransfers) == 1 {
+			currAddr = tokenTransfers[0].TokenAddr
+			currDecimals = tokenTransfers[0].Decimals
+
+			if v := tokenTransfers[0].TokenSymbol; v != nil {
+				currSymbol = *v
+			}
+		}
+	}
+
+	transfers, err := s.findERC721Transfers(ctx, receipt)
+	if err != nil {
+		log.Errorf("unable to find transfers of the event(block: %d, tx index: %d, tx: %s): %s", ev.Raw.BlockNumber, ev.Raw.TxIndex, ev.Raw.TxHash.Hex(), err.Error())
+
+		return false, err
+	}
+
+	// skip if the event has no transfer
+	if len(transfers) == 0 {
+		log.Tracef("event(block: %d, tx index: %d, tx: %s) skipped due to it has no erc721 transfer log", ev.Raw.BlockNumber, ev.Raw.TxIndex, ev.Raw.TxHash.Hex())
+
+		return true, nil
+	}
+
+	// skip if the event has multiple transfers due to we can't calculate the price of trade
+	if len(transfers) > 1 {
+		log.Tracef("event(block: %d, tx index: %d, tx: %s) skipped due to it has multiple erc721 transfer logs", ev.Raw.BlockNumber, ev.Raw.TxIndex, ev.Raw.TxHash.Hex())
+
+		return true, nil
+	}
+
+	if transfers[0].NFTAddress == common.HexToAddress("0xA5c807A62CD6774d6BF518dD2dEc0aE17446Ad8d") {
+		log.Warnf("skip class %s because of decoding error.", "0xA5c807A62CD6774d6BF518dD2dEc0aE17446Ad8d")
+
+		return true, nil
+	}
+
+	normPrice := decimal.NewFromBigInt(big.NewInt(0), 0).Div(decimal.NewFromInt(10).Pow(decimal.NewFromInt(int64(currDecimals))))
+
+	usdPrice, err := s.calcUSDPrice(ev.Raw.BlockNumber, currAddr, currSymbol, normPrice)
+	if err != nil {
+		log.Errorf("unable to calculate usd price of the event(block: %d, log: %d, tx: %s): %s", ev.Raw.BlockNumber, ev.Raw.TxIndex, ev.Raw.TxHash.Hex(), err.Error())
+
+		return false, err
+	}
+
+	// HOW MUCH DID THE TRANSACTION COST - WHOLE VALUE? SUM?
+	if err := s.notifyTrade(ev, transfers[0], big.NewInt(0), normPrice, usdPrice, currSymbol, currAddr); err != nil {
+		if !errors.Is(err, errOpenSeaSeaportShutdownRequest) {
+			log.Warnf("event(block: %d, tx index: %d, tx: %s) couldn't processed: %s", ev.Raw.BlockNumber, ev.Raw.TxIndex, ev.Raw.TxHash.Hex(), err.Error())
+		}
+
+		return false, err
+	}
+
+	return false, nil
+}
+
+func (s *OpenSeaSeaportScraper) notifyTrade(ev *openseaseaport.OpenseaseaportOrderFulfilled, transfer *erc721Transfer, price *big.Int, priceDec decimal.Decimal, usdPrice float64, currSymbol string, currAddr common.Address) error {
+	nftClass, err := s.createOrReadNFTClass(transfer)
+	if err != nil {
+		return err
+	}
+
+	nft, err := s.createOrReadNFT(nftClass, transfer)
+	if err != nil {
+		return err
+	}
+
+	// Get block time.
+	timestamp, err := ethhelper.GetBlockTimeEth(int64(ev.Raw.BlockNumber), s.tradeScraper.datastore, s.tradeScraper.ethConnection)
+	if err != nil {
+		log.Errorf("getting block time: %+v", err)
+	}
+
+	trade := dia.NFTTrade{
+		NFT:         *nft,
+		Price:       price,
+		PriceUSD:    usdPrice,
+		FromAddress: transfer.From.Hex(),
+		ToAddress:   transfer.To.Hex(),
+		BlockNumber: ev.Raw.BlockNumber,
+		Timestamp:   timestamp,
+		TxHash:      ev.Raw.TxHash.Hex(),
+		Exchange:    "OpenSeaSeaport",
+	}
+
+	if asset, ok := assetCacheOpensea[dia.ETHEREUM+"-"+currAddr.Hex()]; ok {
+		trade.Currency = asset
+	} else {
+		currency, err := s.tradeScraper.datastore.GetAsset(currAddr.Hex(), dia.ETHEREUM)
+		if err != nil {
+			log.Errorf("cannot fetch asset %s -- %s | error: %v", dia.ETHEREUM, currAddr.Hex(), err)
+		}
+		trade.Currency = currency
+		assetCacheOpensea[dia.ETHEREUM+"-"+currAddr.Hex()] = currency
+	}
+
+	log.Infof("found trade: %v", trade)
+
+	// handle close request if the chanTrade not consumed immediately
+	select {
+	case s.tradeScraper.chanTrade <- trade:
+	case <-s.tradeScraper.shutdown:
+		return errOpenSeaSeaportShutdownRequest
+	}
+
+	return nil
+}
+
+func (s *OpenSeaSeaportScraper) createOrReadNFTClass(transfer *erc721Transfer) (*dia.NFTClass, error) {
+	nftClass, err := s.tradeScraper.datastore.GetNFTClass(transfer.NFTAddress.Hex(), dia.ETHEREUM)
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			log.Warnf("unable to read nftclass from reldb: %s", err.Error())
+
+			return nil, err
+		}
+
+		nftClass = dia.NFTClass{
+			Address:      transfer.NFTAddress.Hex(),
+			Blockchain:   dia.ETHEREUM,
+			ContractType: openSeaSeaportNFTContractType,
+		}
+
+		if transfer.Name != nil {
+			nftClass.Name = *transfer.Name
+		}
+
+		if transfer.Symbol != nil {
+			nftClass.Symbol = *transfer.Symbol
+		}
+
+		if err = s.tradeScraper.datastore.SetNFTClass(nftClass); err != nil {
+			log.Warnf("unable to create nftclass on reldb: %s", err.Error())
+
+			return nil, err
+		}
+	}
+
+	return &nftClass, nil
+}
+
+func (s *OpenSeaSeaportScraper) createOrReadNFT(nftClass *dia.NFTClass, transfer *erc721Transfer) (*dia.NFT, error) {
+	nft, err := s.tradeScraper.datastore.GetNFT(nftClass.Address, dia.ETHEREUM, transfer.TokenID.String())
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			log.Warnf("unable to read nft from reldb: %s", err.Error())
+
+			return nil, err
+		}
+
+		createdBy, createdAt, err := s.findContractCreationInfo(context.Background(), common.HexToAddress(nftClass.Address))
+		if err != nil {
+			log.Warnf("unable to find the creation info for the nft contract(%s): %s", nftClass.Address, err.Error())
+
+			return nil, err
+		}
+
+		nft = dia.NFT{
+			NFTClass:       *nftClass,
+			TokenID:        transfer.TokenID.String(),
+			CreationTime:   createdAt,
+			CreatorAddress: createdBy.Hex(),
+			Attributes:     transfer.TokenAttrs,
+		}
+
+		if transfer.TokenURI != nil {
+			nft.URI = *transfer.TokenURI
+		}
+
+		if err = s.tradeScraper.datastore.SetNFT(nft); err != nil {
+			log.Warnf("unable to create nft on reldb: %s", err.Error())
+
+			return nil, err
+		}
+	}
+
+	return &nft, nil
+}
+
+func (s *OpenSeaSeaportScraper) calcUSDPrice(blockNum uint64, tokenAddr common.Address, symbol string, price decimal.Decimal) (float64, error) {
+	tokenPrice, err := s.findPrice(blockNum, tokenAddr, symbol)
+	if err != nil {
+		return 0, err
+	}
+
+	usdPrice := price.Mul(tokenPrice)
+
+	// using float type is not a good idea to handle prices
+	// we ignore if the price cannot be presentable as float64
+	f, _ := usdPrice.Float64()
+
+	return f, nil
+}
+
+func (s *OpenSeaSeaportScraper) findPrice(blockNum uint64, tokenAddr common.Address, symbol string) (decimal.Decimal, error) {
+	// TODO: find the token price in usd for the given block number
+	switch symbol {
+	case "ETH", "WETH":
+		return decimal.NewFromString("1045.0910")
+
+	case "MANA":
+		return decimal.NewFromString("0.5")
+
+	default:
+		return decimal.NewFromString("1")
+	}
+}
+
+// GetTradeChannel returns the scrapers data channel.
+func (s *OpenSeaSeaportScraper) GetTradeChannel() chan dia.NFTTrade {
+	return s.tradeScraper.chanTrade
+}
+
+func (s *OpenSeaSeaportScraper) Close() error {
+	if s.tradeScraper.closed {
+		return errors.New("scraper already closed")
+	}
+
+	close(s.tradeScraper.shutdown)
+
+	return nil
+}
+
+// it searches the creation transaction for the given contract address using binary search in complexity of o(log n)
+func (s *OpenSeaSeaportScraper) findContractCreationInfo(ctx context.Context, contractAddr common.Address) (createdBy common.Address, createdAt time.Time, err error) {
+	if !s.conf.UseArchiveNode {
+		log.Trace("nft contract creation info could not found because UseArchiveNode flag is not set, using zero values")
+		return common.Address{}, time.Time{}, nil
+	}
+
+	var (
+		lo, hi, blockNum uint64
+		code             []byte
+		receipt          *types.Receipt
+		chainID          *big.Int
+		block            *types.Block
+	)
+
+	hi, err = s.tradeScraper.ethConnection.BlockNumber(ctx)
+	if err != nil {
+		return
+	}
+
+	for lo <= hi {
+		blockNum = (lo + hi) / 2
+
+		code, err = s.tradeScraper.ethConnection.CodeAt(ctx, contractAddr, new(big.Int).SetUint64(blockNum))
+		if err != nil {
+			return
+		}
+
+		if len(code) == 0 {
+			lo = blockNum
+		} else {
+			hi = blockNum
+		}
+
+		if hi == lo+1 {
+			blockNum = hi
+			break
+		}
+	}
+
+	block, err = s.tradeScraper.ethConnection.BlockByNumber(ctx, new(big.Int).SetUint64(blockNum))
+	if err != nil {
+		return
+	}
+
+	chainID, err = s.tradeScraper.ethConnection.NetworkID(ctx)
+	if err != nil {
+		return
+	}
+
+	signer := types.NewEIP155Signer(chainID)
+
+	for _, trx := range block.Transactions() {
+		// recipient must be nill for contract creation transactions
+		if trx.To() != nil {
+			continue
+		}
+
+		receipt, err = s.tradeScraper.ethConnection.TransactionReceipt(ctx, trx.Hash())
+		if err != nil {
+			return
+		}
+
+		// note that if the nft was created by another smart contract
+		// we can't find its creation info with this method
+		if bytes.Equal(receipt.ContractAddress.Bytes(), contractAddr.Bytes()) {
+			createdAt = time.Unix(int64(block.Time()), 0).UTC()
+			createdBy, err = types.Sender(signer, trx)
+			if err != nil {
+				return
+			}
+
+			return
+		}
+	}
+
+	return
+}
+
+func (s *OpenSeaSeaportScraper) findERC20Transfers(ctx context.Context, receipt *types.Receipt, filterAmount *big.Int) ([]*erc20Transfer, error) {
+	transfers := make([]*erc20Transfer, 0, 2)
+
+	for _, txLog := range receipt.Logs {
+		if len(txLog.Topics) < 1 || txLog.Topics[0] != erc20ABI.Events["Transfer"].ID {
+			continue
+		}
+
+		token, err := erc20.NewERC20(txLog.Address, s.tradeScraper.ethConnection)
+		if err != nil {
+			log.Warnf("unable to bind erc720 contract at address %s: %s", txLog.Address.Hex(), err.Error())
+			continue
+		}
+
+		ev, err := token.ParseTransfer(*txLog)
+		if err != nil {
+			log.Tracef("the event cannot comply to erc20's transfer: %s", err)
+			continue
+		}
+
+		if filterAmount != nil && filterAmount.Cmp(ev.Value) != 0 {
+			continue
+		}
+
+		transfer := &erc20Transfer{
+			TokenAddr: txLog.Address,
+			From:      ev.From,
+			To:        ev.To,
+			Amount:    ev.Value,
+			Decimals:  1,
+		}
+
+		transfers = append(transfers, transfer)
+
+		metadata, err := erc20.NewERC20Metadata(txLog.Address, s.tradeScraper.ethConnection)
+		if err != nil {
+			log.Warnf("unable to bind erc20 metadata contract at address %s: %s", txLog.Address.Hex(), err.Error())
+			continue
+		}
+
+		callOpts := &bind.CallOpts{Context: ctx}
+
+		if s.conf.UseArchiveNode {
+			callOpts.BlockNumber = new(big.Int).SetUint64(txLog.BlockNumber)
+		}
+
+		symbol, err := metadata.Symbol(callOpts)
+		if err != nil {
+			log.Warnf("unable to read token symbol from metadata interface of erc20(addr: %s): %s", txLog.Address.Hex(), err.Error())
+			continue
+		}
+
+		transfer.TokenSymbol = &symbol
+
+		decimals, err := metadata.Decimals(callOpts)
+		if err != nil {
+			log.Warnf("unable to read token decimals from metadata interface of erc20(addr: %s): %s", txLog.Address.Hex(), err.Error())
+			continue
+		}
+
+		transfer.Decimals = int(decimals)
+	}
+
+	return transfers, nil
+}
+
+// it finds the transfer events of ERC721 in the given transaction
+func (s *OpenSeaSeaportScraper) findERC721Transfers(ctx context.Context, receipt *types.Receipt) ([]*erc721Transfer, error) {
+	transfers := make([]*erc721Transfer, 0, 1)
+
+	for _, txLog := range receipt.Logs {
+		if len(txLog.Topics) < 1 || txLog.Topics[0] != erc721ABI.Events["Transfer"].ID {
+			continue
+		}
+
+		nft, err := erc721.NewERC721(txLog.Address, s.tradeScraper.ethConnection)
+		if err != nil {
+			log.Warnf("unable to bind erc721 contract at address %s: %s", txLog.Address.Hex(), err.Error())
+			continue
+		}
+
+		transferLog, err := nft.ParseTransfer(*txLog)
+		if err != nil {
+			// it means this log data not comply to erc721's transfer event
+			//
+			// some old erc721 contracts have unindexed tokenid parameter
+			// so it is not compliant with the eip-721.
+
+			// best effort...
+			compat, err := erc721.NewERC721Compat(txLog.Address, s.tradeScraper.ethConnection)
+			if err != nil {
+				log.Warnf("unable to bind erc721compat contract at address %s: %s", txLog.Address.Hex(), err.Error())
+				continue
+			}
+
+			compatLog, err := compat.ParseTransfer(*txLog)
+			if err != nil {
+				log.Tracef("the event cannot comply to erc721's transfer: %s", err)
+				continue
+			}
+
+			transferLog = &erc721.ERC721Transfer{
+				From:    compatLog.From,
+				To:      compatLog.To,
+				TokenId: compatLog.TokenId,
+				Raw:     compatLog.Raw,
+			}
+		}
+
+		transfer := &erc721Transfer{
+			NFTAddress: txLog.Address,
+			From:       transferLog.From,
+			To:         transferLog.To,
+			TokenID:    transferLog.TokenId,
+			TokenAttrs: make(map[string]interface{}),
+		}
+
+		callOpts := &bind.CallOpts{Context: ctx}
+
+		if s.conf.UseArchiveNode {
+			callOpts.BlockNumber = new(big.Int).SetUint64(txLog.BlockNumber)
+		}
+
+		if md, err := erc721.NewERC721Metadata(txLog.Address, s.tradeScraper.ethConnection); err != nil {
+			log.Warnf("unable to bind erc721 metadata contract at address %s: %s", txLog.Address.Hex(), err.Error())
+		} else {
+			if nftName, err := md.Name(callOpts); err != nil {
+				log.Warnf("unable to read nft name from metadata interface of erc721(addr: %s): %s", txLog.Address.Hex(), err.Error())
+			} else {
+				transfer.Name = &nftName
+			}
+
+			if nftSymbol, err := md.Symbol(callOpts); err != nil {
+				log.Warnf("unable to read nft symbol from metadata interface of nft(addr: %s): %s", txLog.Address.Hex(), err.Error())
+			} else {
+				transfer.Symbol = &nftSymbol
+			}
+
+			if tokenURI, err := md.TokenURI(callOpts, transfer.TokenID); err != nil {
+				log.Warnf("unable to find token(%s) uri: %s", transfer.TokenID.String(), err.Error())
+			} else if attrs, err := s.readNFTAttr(ctx, tokenURI); err != nil {
+				log.Warnf("unable to read token(%s) attributes: %s", transfer.TokenID.String(), err.Error())
+			} else {
+				transfer.TokenURI = &tokenURI
+				transfer.TokenAttrs = attrs
+			}
+		}
+
+		transfers = append(transfers, transfer)
+	}
+
+	return transfers, nil
+}
+
+func (s *OpenSeaSeaportScraper) readNFTAttr(ctx context.Context, uri string) (map[string]interface{}, error) {
+	if uri == "" {
+		return nil, nil
+	}
+
+	if strings.HasPrefix(uri, "ipfs://") {
+		// TODO: add IPFS support
+		return nil, nil
+	}
+
+	attrs := make(map[string]interface{})
+
+	ctx, cancel := context.WithTimeout(ctx, s.conf.MetadataTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errors.New("unable to read token attributes: " + resp.Status)
+	}
+
+	if err := json.NewDecoder(io.LimitReader(resp.Body, int64(s.conf.MaxMetadataSize))).Decode(&attrs); err != nil {
+		return nil, err
+	}
+
+	return attrs, nil
+}

--- a/pkg/dia/nft/nftTrade-scrapers/openseaSeaport.go
+++ b/pkg/dia/nft/nftTrade-scrapers/openseaSeaport.go
@@ -237,9 +237,6 @@ func (s *OpenSeaSeaportScraper) mainLoop() {
 		close(s.tradeScraper.shutdownDone)
 	}()
 
-	c := defOpenSeaSeaportConf
-	s.conf = &c
-
 	log.Infof("opensea scraper has been started (batch: %d, period: %s)", s.conf.BatchSize, s.conf.WaitPeriod.String())
 
 	for stop := false; !stop; {
@@ -285,9 +282,6 @@ func (s *OpenSeaSeaportScraper) FetchTrades() error {
 
 		return err
 	}
-
-	c := defOpenSeaSeaportConf
-	s.conf = &c
 
 	log.Infof("fetching opensea trade transactions from block %d(+%d)", s.state.LastBlockNum, s.conf.BatchSize)
 
@@ -514,10 +508,16 @@ func (s *OpenSeaSeaportScraper) notifyTrade(ev *openseaseaport.OpenseaseaportOrd
 		}
 
 		trade := dia.NFTTrade{
-			NFT:         *nft,
-			// what should be in this place? Code snippet based on opensea.go, what does this value represent?
-			Price:       normPrice.BigInt(),
-			PriceUSD:    usdPrice,
+			NFT:      *nft,
+			Price:    asset.Amount,
+			PriceUSD: usdPrice,
+			Currency: dia.Asset{
+				Symbol:     *transfer.Symbol,
+				Name:       *transfer.Name,
+				Address:    transfer.NFTAddress.String(),
+				Decimals:   currDecimals,
+				Blockchain: datastoreAsset.Blockchain,
+			},
 			FromAddress: transfer.From.Hex(),
 			ToAddress:   transfer.To.Hex(),
 			BlockNumber: ev.Raw.BlockNumber,


### PR DESCRIPTION
## Description

This PR provides new NFT trade scraper that scrapes trades from Opensea's new Seaport 1.1 contract. It manages trades that involve new multi-asset trade between two parties (more information about this sytem [here](https://opensea.io/blog/announcements/launching-seaport-saving-the-community-millions-in-fees/)

## Done

- [X] Fetching trades based on `OrderFulfilled` event
- [X] Passing trades through the NFT trade channel
- [X] Using generated ABI bindings for Seaport contract
- [X] Insert token types into postrges database 
- [X] Aggregate consideration into separate trades
- [X] Insert trades into postgres database (`nfttrade` table throws errors)

## To do

None

## Manual checks

- [X] Running locally (this needs some extra steps, like setting up databases and running other services)

## Resources

* [Seaport's github](https://github.com/ProjectOpenSea/seaport)
* [Seaport's contract]( https://etherscan.io/address/0x00000000006c3852cbef3e08e8df289169ede581)

## Known issues

- Running scraper is hard and needs many extra steps, while the process itself isn't directly documented anywhere in the project

## Linked PRs

None