### PR TITLE
Add BitMart exchange scraper

### DIFF
--- a/config/BitMart.json
+++ b/config/BitMart.json
@@ -1,0 +1,5776 @@
+{
+  "Coins": [
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SOLAR_USDT",
+      "Ignore": false,
+      "Symbol": "SOLAR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PRQ_BTC",
+      "Ignore": false,
+      "Symbol": "PRQ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QNT_USDT",
+      "Ignore": false,
+      "Symbol": "QNT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KOM_USDT",
+      "Ignore": false,
+      "Symbol": "KOM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GAMI_USDT",
+      "Ignore": false,
+      "Symbol": "GAMI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DASH_BTC",
+      "Ignore": false,
+      "Symbol": "DASH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DGB_BTC",
+      "Ignore": false,
+      "Symbol": "DGB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ALGX_USDT",
+      "Ignore": false,
+      "Symbol": "ALGX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TNNS_USDT",
+      "Ignore": false,
+      "Symbol": "TNNS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CFXT_USDT",
+      "Ignore": false,
+      "Symbol": "CFXT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TERA_USDT",
+      "Ignore": false,
+      "Symbol": "TERA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WEMP_USDT",
+      "Ignore": false,
+      "Symbol": "WEMP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TWT_USDT",
+      "Ignore": false,
+      "Symbol": "TWT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SBR_USDT",
+      "Ignore": false,
+      "Symbol": "SBR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CCX_USDT",
+      "Ignore": false,
+      "Symbol": "CCX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FALCONS_USDT",
+      "Ignore": false,
+      "Symbol": "FALCONS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHIBORG_USDT",
+      "Ignore": false,
+      "Symbol": "SHIBORG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HERO_USDT",
+      "Ignore": false,
+      "Symbol": "HERO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "2022M_USDT",
+      "Ignore": false,
+      "Symbol": "2022M"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KATA_USDT",
+      "Ignore": false,
+      "Symbol": "KATA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MC_USDT",
+      "Ignore": false,
+      "Symbol": "MC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FNF_USDT",
+      "Ignore": false,
+      "Symbol": "FNF"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VET_USDT",
+      "Ignore": false,
+      "Symbol": "VET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GARI_USDT",
+      "Ignore": false,
+      "Symbol": "GARI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$EWT_USDT",
+      "Ignore": false,
+      "Symbol": "$EWT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QUINT_USDT",
+      "Ignore": false,
+      "Symbol": "QUINT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LIST_USDT",
+      "Ignore": false,
+      "Symbol": "LIST"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FTS_USDT",
+      "Ignore": false,
+      "Symbol": "FTS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LYXE_USDT",
+      "Ignore": false,
+      "Symbol": "LYXE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LAEEB_USDT",
+      "Ignore": false,
+      "Symbol": "LAEEB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TASTE_USDT",
+      "Ignore": false,
+      "Symbol": "TASTE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OPUL_USDT",
+      "Ignore": false,
+      "Symbol": "OPUL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "IUX_USDT",
+      "Ignore": false,
+      "Symbol": "IUX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AVAT_USDT",
+      "Ignore": false,
+      "Symbol": "AVAT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FOTA_USDT",
+      "Ignore": false,
+      "Symbol": "FOTA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UBT_USDT",
+      "Ignore": false,
+      "Symbol": "UBT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GGG_USDT",
+      "Ignore": false,
+      "Symbol": "GGG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FET_USDT",
+      "Ignore": false,
+      "Symbol": "FET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ARG_USDT",
+      "Ignore": false,
+      "Symbol": "ARG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UNI_USDT",
+      "Ignore": false,
+      "Symbol": "UNI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CWEB_USDT",
+      "Ignore": false,
+      "Symbol": "CWEB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CIV_USDT",
+      "Ignore": false,
+      "Symbol": "CIV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SOM_USDT",
+      "Ignore": false,
+      "Symbol": "SOM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ATR_USDT",
+      "Ignore": false,
+      "Symbol": "ATR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TVG_USDT",
+      "Ignore": false,
+      "Symbol": "TVG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WMT_USDT",
+      "Ignore": false,
+      "Symbol": "WMT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SG_BTC",
+      "Ignore": false,
+      "Symbol": "SG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ROCKI_USDT",
+      "Ignore": false,
+      "Symbol": "ROCKI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GMT_USDT",
+      "Ignore": false,
+      "Symbol": "GMT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SST_BTC",
+      "Ignore": false,
+      "Symbol": "SST"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CSPR_USDT",
+      "Ignore": false,
+      "Symbol": "CSPR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ALGO_BTC",
+      "Ignore": false,
+      "Symbol": "ALGO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GMCOIN_USDT",
+      "Ignore": false,
+      "Symbol": "GMCOIN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MERCE_USDT",
+      "Ignore": false,
+      "Symbol": "MERCE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FIU_USDT",
+      "Ignore": false,
+      "Symbol": "FIU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ALGOBLK_USDT",
+      "Ignore": false,
+      "Symbol": "ALGOBLK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QRDO_USDT",
+      "Ignore": false,
+      "Symbol": "QRDO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BSHEESHA_USDT",
+      "Ignore": false,
+      "Symbol": "BSHEESHA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GRT_USDT",
+      "Ignore": false,
+      "Symbol": "GRT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHA_USDT",
+      "Ignore": false,
+      "Symbol": "SHA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PAF_USDT",
+      "Ignore": false,
+      "Symbol": "PAF"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EGLD_USDT",
+      "Ignore": false,
+      "Symbol": "EGLD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DAI_USDT",
+      "Ignore": false,
+      "Symbol": "DAI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DATE_USDT",
+      "Ignore": false,
+      "Symbol": "DATE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "APOLLO_USDT",
+      "Ignore": false,
+      "Symbol": "APOLLO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LOKA_USDT",
+      "Ignore": false,
+      "Symbol": "LOKA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KILLER_USDT",
+      "Ignore": false,
+      "Symbol": "KILLER"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CREO_USDT",
+      "Ignore": false,
+      "Symbol": "CREO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WLKN_USDT",
+      "Ignore": false,
+      "Symbol": "WLKN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STMX_USDT",
+      "Ignore": false,
+      "Symbol": "STMX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SKL_USDT",
+      "Ignore": false,
+      "Symbol": "SKL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DTR_USDT",
+      "Ignore": false,
+      "Symbol": "DTR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NFC_USDT",
+      "Ignore": false,
+      "Symbol": "NFC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DAI_USDC",
+      "Ignore": false,
+      "Symbol": "DAI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ATOZ_USDT",
+      "Ignore": false,
+      "Symbol": "ATOZ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "YCO_USDC",
+      "Ignore": false,
+      "Symbol": "YCO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DCN_USDT",
+      "Ignore": false,
+      "Symbol": "DCN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BRISE_USDT",
+      "Ignore": false,
+      "Symbol": "BRISE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BHD_USDT",
+      "Ignore": false,
+      "Symbol": "BHD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VODKA_USDT",
+      "Ignore": false,
+      "Symbol": "VODKA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MrFOX_USDT",
+      "Ignore": false,
+      "Symbol": "MrFOX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AFEN_USDT",
+      "Ignore": false,
+      "Symbol": "AFEN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ANON_USDT",
+      "Ignore": false,
+      "Symbol": "ANON"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MATIC_USDT",
+      "Ignore": false,
+      "Symbol": "MATIC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BOBC_USDT",
+      "Ignore": false,
+      "Symbol": "BOBC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MVEDA_USDT",
+      "Ignore": false,
+      "Symbol": "MVEDA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FTT_USDT",
+      "Ignore": false,
+      "Symbol": "FTT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VEIL_USDT",
+      "Ignore": false,
+      "Symbol": "VEIL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ASSA_USDT",
+      "Ignore": false,
+      "Symbol": "ASSA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "USDP_USDC",
+      "Ignore": false,
+      "Symbol": "USDP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MATIC_USDC",
+      "Ignore": false,
+      "Symbol": "MATIC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BBT_USDT",
+      "Ignore": false,
+      "Symbol": "BBT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AXL_USDT",
+      "Ignore": false,
+      "Symbol": "AXL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PLEX_BTC",
+      "Ignore": false,
+      "Symbol": "PLEX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RBT_USDT",
+      "Ignore": false,
+      "Symbol": "RBT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VLX_USDT",
+      "Ignore": false,
+      "Symbol": "VLX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AST_USDT",
+      "Ignore": false,
+      "Symbol": "AST"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XAVA_USDT",
+      "Ignore": false,
+      "Symbol": "XAVA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BNB_USDT",
+      "Ignore": false,
+      "Symbol": "BNB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BDY_USDT",
+      "Ignore": false,
+      "Symbol": "BDY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PBR_USDT",
+      "Ignore": false,
+      "Symbol": "PBR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DOGEMETA_USDT",
+      "Ignore": false,
+      "Symbol": "DOGEMETA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GERA_ETH",
+      "Ignore": false,
+      "Symbol": "GERA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KT_USDT",
+      "Ignore": false,
+      "Symbol": "KT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "USDP_USDT",
+      "Ignore": false,
+      "Symbol": "USDP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ALPINE_USDT",
+      "Ignore": false,
+      "Symbol": "ALPINE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MONOPOLYMETA_USDT",
+      "Ignore": false,
+      "Symbol": "MONOPOLYMETA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LEZ_USDT",
+      "Ignore": false,
+      "Symbol": "LEZ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XDNA_BTC",
+      "Ignore": false,
+      "Symbol": "XDNA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GUSD_USDT",
+      "Ignore": false,
+      "Symbol": "GUSD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PKT_USDT",
+      "Ignore": false,
+      "Symbol": "PKT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DFA_USDT",
+      "Ignore": false,
+      "Symbol": "DFA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BORA_USDT",
+      "Ignore": false,
+      "Symbol": "BORA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "YFI_USDT",
+      "Ignore": false,
+      "Symbol": "YFI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DASH_USDT",
+      "Ignore": false,
+      "Symbol": "DASH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ESW_ETH",
+      "Ignore": false,
+      "Symbol": "ESW"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WPP_USDT",
+      "Ignore": false,
+      "Symbol": "WPP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FORT_USDT",
+      "Ignore": false,
+      "Symbol": "FORT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XSP_USDT",
+      "Ignore": false,
+      "Symbol": "XSP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SPE_USDT",
+      "Ignore": false,
+      "Symbol": "SPE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VISION_USDT",
+      "Ignore": false,
+      "Symbol": "VISION"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HDAO_USDT",
+      "Ignore": false,
+      "Symbol": "HDAO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VRA_USDT",
+      "Ignore": false,
+      "Symbol": "VRA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SRX_USDT",
+      "Ignore": false,
+      "Symbol": "SRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MRX_USDT",
+      "Ignore": false,
+      "Symbol": "MRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WRK_USDT",
+      "Ignore": false,
+      "Symbol": "WRK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SLEEPEE_USDT",
+      "Ignore": false,
+      "Symbol": "SLEEPEE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MUSC_USDT",
+      "Ignore": false,
+      "Symbol": "MUSC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "COL_USDT",
+      "Ignore": false,
+      "Symbol": "COL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XI_USDT",
+      "Ignore": false,
+      "Symbol": "XI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ACU_USDT",
+      "Ignore": false,
+      "Symbol": "ACU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "APP_USDT",
+      "Ignore": false,
+      "Symbol": "APP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AETH_USDT",
+      "Ignore": false,
+      "Symbol": "AETH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRX_ETH",
+      "Ignore": false,
+      "Symbol": "TRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NEAR_USDT",
+      "Ignore": false,
+      "Symbol": "NEAR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SOL_USDC",
+      "Ignore": false,
+      "Symbol": "SOL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CENX_USDT",
+      "Ignore": false,
+      "Symbol": "CENX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZOON_USDT",
+      "Ignore": false,
+      "Symbol": "ZOON"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XLM_ETH",
+      "Ignore": false,
+      "Symbol": "XLM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GMD_USDT",
+      "Ignore": false,
+      "Symbol": "GMD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LNR_USDT",
+      "Ignore": false,
+      "Symbol": "LNR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WEC_USDT",
+      "Ignore": false,
+      "Symbol": "WEC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "THG_USDT",
+      "Ignore": false,
+      "Symbol": "THG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZRX_ETH",
+      "Ignore": false,
+      "Symbol": "ZRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NASSR_USDT",
+      "Ignore": false,
+      "Symbol": "NASSR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "POLY_USDT",
+      "Ignore": false,
+      "Symbol": "POLY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EMC1_USDT",
+      "Ignore": false,
+      "Symbol": "EMC1"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KKT_USDT",
+      "Ignore": false,
+      "Symbol": "KKT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SOL_USDT",
+      "Ignore": false,
+      "Symbol": "SOL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GAIA_USDT",
+      "Ignore": false,
+      "Symbol": "GAIA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AXS_USDT",
+      "Ignore": false,
+      "Symbol": "AXS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CTN_USDT",
+      "Ignore": false,
+      "Symbol": "CTN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FTM_USDT",
+      "Ignore": false,
+      "Symbol": "FTM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FIO_USDT",
+      "Ignore": false,
+      "Symbol": "FIO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BHAX_USDT",
+      "Ignore": false,
+      "Symbol": "BHAX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TITAN_USDT",
+      "Ignore": false,
+      "Symbol": "TITAN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PIG_USDT",
+      "Ignore": false,
+      "Symbol": "PIG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BXTB_USDT",
+      "Ignore": false,
+      "Symbol": "BXTB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$CRDN_USDT",
+      "Ignore": false,
+      "Symbol": "$CRDN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "THN_USDT",
+      "Ignore": false,
+      "Symbol": "THN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LUFFY_USDT",
+      "Ignore": false,
+      "Symbol": "LUFFY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ELON_USDT",
+      "Ignore": false,
+      "Symbol": "ELON"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SKL_ETH",
+      "Ignore": false,
+      "Symbol": "SKL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BSP_USDT",
+      "Ignore": false,
+      "Symbol": "BSP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZNC_USDT",
+      "Ignore": false,
+      "Symbol": "ZNC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "POT_USDT",
+      "Ignore": false,
+      "Symbol": "POT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HOTCROSS_USDT",
+      "Ignore": false,
+      "Symbol": "HOTCROSS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EVER_USDT",
+      "Ignore": false,
+      "Symbol": "EVER"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TABOO_USDT",
+      "Ignore": false,
+      "Symbol": "TABOO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BANANA_USDT",
+      "Ignore": false,
+      "Symbol": "BANANA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WAVES_USDT",
+      "Ignore": false,
+      "Symbol": "WAVES"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MON_USDT",
+      "Ignore": false,
+      "Symbol": "MON"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SFT_USDT",
+      "Ignore": false,
+      "Symbol": "SFT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MBET_USDT",
+      "Ignore": false,
+      "Symbol": "MBET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SOS_USDT",
+      "Ignore": false,
+      "Symbol": "SOS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHIBDOGE(1M)_USDT",
+      "Ignore": false,
+      "Symbol": "SHIBDOGE(1M)"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PEOPLE_USDT",
+      "Ignore": false,
+      "Symbol": "PEOPLE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "POLC_USDT",
+      "Ignore": false,
+      "Symbol": "POLC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RITE_USDT",
+      "Ignore": false,
+      "Symbol": "RITE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KAINET_USDT",
+      "Ignore": false,
+      "Symbol": "KAINET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HEX_BTC",
+      "Ignore": false,
+      "Symbol": "HEX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ESHEESHA_USDT",
+      "Ignore": false,
+      "Symbol": "ESHEESHA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AVN_USDT",
+      "Ignore": false,
+      "Symbol": "AVN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BHC_USDT",
+      "Ignore": false,
+      "Symbol": "BHC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHIBA_USDT",
+      "Ignore": false,
+      "Symbol": "SHIBA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LTC_ETH",
+      "Ignore": false,
+      "Symbol": "LTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZPAY_USDT",
+      "Ignore": false,
+      "Symbol": "ZPAY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ICW_USDT",
+      "Ignore": false,
+      "Symbol": "ICW"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RISE_USDT",
+      "Ignore": false,
+      "Symbol": "RISE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DFI_ETH",
+      "Ignore": false,
+      "Symbol": "DFI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FRZSS_USDT",
+      "Ignore": false,
+      "Symbol": "FRZSS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LINK_BTC",
+      "Ignore": false,
+      "Symbol": "LINK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KALAM_USDT",
+      "Ignore": false,
+      "Symbol": "KALAM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FIRO_USDT",
+      "Ignore": false,
+      "Symbol": "FIRO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AUDIO_USDT",
+      "Ignore": false,
+      "Symbol": "AUDIO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MANA_USDT",
+      "Ignore": false,
+      "Symbol": "MANA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OKB_USDT",
+      "Ignore": false,
+      "Symbol": "OKB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SLP_USDT",
+      "Ignore": false,
+      "Symbol": "SLP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LUNA_USDT",
+      "Ignore": false,
+      "Symbol": "LUNA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UNITS_USDT",
+      "Ignore": false,
+      "Symbol": "UNITS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MGT_USDT",
+      "Ignore": false,
+      "Symbol": "MGT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TCG2_USDT",
+      "Ignore": false,
+      "Symbol": "TCG2"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AMA_USDT",
+      "Ignore": false,
+      "Symbol": "AMA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UNC_USDT",
+      "Ignore": false,
+      "Symbol": "UNC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XETA_USDT",
+      "Ignore": false,
+      "Symbol": "XETA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RFUEL_USDT",
+      "Ignore": false,
+      "Symbol": "RFUEL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MRI_USDT",
+      "Ignore": false,
+      "Symbol": "MRI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ADS_USDT",
+      "Ignore": false,
+      "Symbol": "ADS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MIR_USDT",
+      "Ignore": false,
+      "Symbol": "MIR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DAR_USDT",
+      "Ignore": false,
+      "Symbol": "DAR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WOLVERINU_USDT",
+      "Ignore": false,
+      "Symbol": "WOLVERINU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KSM_USDT",
+      "Ignore": false,
+      "Symbol": "KSM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STORJ_USDT",
+      "Ignore": false,
+      "Symbol": "STORJ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XEM_USDT",
+      "Ignore": false,
+      "Symbol": "XEM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SMILE_USDT",
+      "Ignore": false,
+      "Symbol": "SMILE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QTUM_USDT",
+      "Ignore": false,
+      "Symbol": "QTUM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WNK_USDT",
+      "Ignore": false,
+      "Symbol": "WNK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LOVELY_USDT",
+      "Ignore": false,
+      "Symbol": "LOVELY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AGV_USDT",
+      "Ignore": false,
+      "Symbol": "AGV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LEXI_USDT",
+      "Ignore": false,
+      "Symbol": "LEXI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "IOTX_USDT",
+      "Ignore": false,
+      "Symbol": "IOTX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CVX_USDT",
+      "Ignore": false,
+      "Symbol": "CVX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LUNC_USDT",
+      "Ignore": false,
+      "Symbol": "LUNC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GMM_USDT",
+      "Ignore": false,
+      "Symbol": "GMM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PSTAKE_USDT",
+      "Ignore": false,
+      "Symbol": "PSTAKE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NEXO_USDT",
+      "Ignore": false,
+      "Symbol": "NEXO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CEL_ETH",
+      "Ignore": false,
+      "Symbol": "CEL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CIND_USDT",
+      "Ignore": false,
+      "Symbol": "CIND"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BORING_USDT",
+      "Ignore": false,
+      "Symbol": "BORING"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KAREN_USDT",
+      "Ignore": false,
+      "Symbol": "KAREN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ETH_USDT",
+      "Ignore": false,
+      "Symbol": "ETH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XET_USDT",
+      "Ignore": false,
+      "Symbol": "XET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZEON_USDT",
+      "Ignore": false,
+      "Symbol": "ZEON"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ETM_USDT",
+      "Ignore": false,
+      "Symbol": "ETM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STORE_USDT",
+      "Ignore": false,
+      "Symbol": "STORE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FLOKI_USDT",
+      "Ignore": false,
+      "Symbol": "FLOKI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XRUN_USDT",
+      "Ignore": false,
+      "Symbol": "XRUN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SFM_USDT",
+      "Ignore": false,
+      "Symbol": "SFM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MNW_USDT",
+      "Ignore": false,
+      "Symbol": "MNW"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SON_USDT",
+      "Ignore": false,
+      "Symbol": "SON"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STRX_USDT",
+      "Ignore": false,
+      "Symbol": "STRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CAST_USDT",
+      "Ignore": false,
+      "Symbol": "CAST"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PEN_USDT",
+      "Ignore": false,
+      "Symbol": "PEN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ETH_USDC",
+      "Ignore": false,
+      "Symbol": "ETH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GLM_USDC",
+      "Ignore": false,
+      "Symbol": "GLM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DXT_USDT",
+      "Ignore": false,
+      "Symbol": "DXT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PUNK_USDT",
+      "Ignore": false,
+      "Symbol": "PUNK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GMR_USDT",
+      "Ignore": false,
+      "Symbol": "GMR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BTCV_BTC",
+      "Ignore": false,
+      "Symbol": "BTCV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CART_USDT",
+      "Ignore": false,
+      "Symbol": "CART"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QI_BTC",
+      "Ignore": false,
+      "Symbol": "QI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DMTR_USDT",
+      "Ignore": false,
+      "Symbol": "DMTR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VAB_USDT",
+      "Ignore": false,
+      "Symbol": "VAB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VANCAT_USDT",
+      "Ignore": false,
+      "Symbol": "VANCAT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ENJ_USDT",
+      "Ignore": false,
+      "Symbol": "ENJ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "YUMMY_USDT",
+      "Ignore": false,
+      "Symbol": "YUMMY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FORM_USDT",
+      "Ignore": false,
+      "Symbol": "FORM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VR_USDT",
+      "Ignore": false,
+      "Symbol": "VR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHIBAPUP_USDT",
+      "Ignore": false,
+      "Symbol": "SHIBAPUP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AIMX_USDT",
+      "Ignore": false,
+      "Symbol": "AIMX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EUM_USDT",
+      "Ignore": false,
+      "Symbol": "EUM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CMCX_USDT",
+      "Ignore": false,
+      "Symbol": "CMCX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DOME_USDT",
+      "Ignore": false,
+      "Symbol": "DOME"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HEC_TOR",
+      "Ignore": false,
+      "Symbol": "HEC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ANKR_USDT",
+      "Ignore": false,
+      "Symbol": "ANKR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FIL_USDT",
+      "Ignore": false,
+      "Symbol": "FIL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRAVA_USDT",
+      "Ignore": false,
+      "Symbol": "TRAVA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WCSOV_USDT",
+      "Ignore": false,
+      "Symbol": "WCSOV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RSS3_USDT",
+      "Ignore": false,
+      "Symbol": "RSS3"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "1USE_USDT",
+      "Ignore": false,
+      "Symbol": "1USE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XCH_USDT",
+      "Ignore": false,
+      "Symbol": "XCH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SUB_USDT",
+      "Ignore": false,
+      "Symbol": "SUB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SCONEX_USDT",
+      "Ignore": false,
+      "Symbol": "SCONEX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PECO_ETH",
+      "Ignore": false,
+      "Symbol": "PECO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PINU_USDT",
+      "Ignore": false,
+      "Symbol": "PINU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ETH_DAI",
+      "Ignore": false,
+      "Symbol": "ETH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHIB_USDC",
+      "Ignore": false,
+      "Symbol": "SHIB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PLASTIK_USDT",
+      "Ignore": false,
+      "Symbol": "PLASTIK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DEBT_USDT",
+      "Ignore": false,
+      "Symbol": "DEBT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SROCKET_USDT",
+      "Ignore": false,
+      "Symbol": "SROCKET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRV_USDT",
+      "Ignore": false,
+      "Symbol": "TRV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "IMPACTXP_USDT",
+      "Ignore": false,
+      "Symbol": "IMPACTXP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$HODL_USDT",
+      "Ignore": false,
+      "Symbol": "$HODL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BAKE_USDT",
+      "Ignore": false,
+      "Symbol": "BAKE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHIB_USDT",
+      "Ignore": false,
+      "Symbol": "SHIB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CYOP_USDT",
+      "Ignore": false,
+      "Symbol": "CYOP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CROGE_USDT",
+      "Ignore": false,
+      "Symbol": "CROGE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BUGG_USDT",
+      "Ignore": false,
+      "Symbol": "BUGG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NFT_USDT",
+      "Ignore": false,
+      "Symbol": "NFT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NORD_USDT",
+      "Ignore": false,
+      "Symbol": "NORD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MONS_USDT",
+      "Ignore": false,
+      "Symbol": "MONS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HOT_ETH",
+      "Ignore": false,
+      "Symbol": "HOT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EVU_USDT",
+      "Ignore": false,
+      "Symbol": "EVU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "O3_USDT",
+      "Ignore": false,
+      "Symbol": "O3"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LXF_USDT",
+      "Ignore": false,
+      "Symbol": "LXF"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MCONTENT_USDT",
+      "Ignore": false,
+      "Symbol": "MCONTENT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EGR_USDT",
+      "Ignore": false,
+      "Symbol": "EGR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BETU_USDT",
+      "Ignore": false,
+      "Symbol": "BETU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRAXX_USDT",
+      "Ignore": false,
+      "Symbol": "TRAXX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHILL_USDT",
+      "Ignore": false,
+      "Symbol": "SHILL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PLI_USDT",
+      "Ignore": false,
+      "Symbol": "PLI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ALGO_USDC",
+      "Ignore": false,
+      "Symbol": "ALGO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KUNCI_USDT",
+      "Ignore": false,
+      "Symbol": "KUNCI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XDC_USDT",
+      "Ignore": false,
+      "Symbol": "XDC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WTK_USDT",
+      "Ignore": false,
+      "Symbol": "WTK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LINK_ETH",
+      "Ignore": false,
+      "Symbol": "LINK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "METO_USDT",
+      "Ignore": false,
+      "Symbol": "METO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WWEB3_USDT",
+      "Ignore": false,
+      "Symbol": "WWEB3"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SOFI_USDT",
+      "Ignore": false,
+      "Symbol": "SOFI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VET_ETH",
+      "Ignore": false,
+      "Symbol": "VET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZEN_USDT",
+      "Ignore": false,
+      "Symbol": "ZEN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ALGO_USDT",
+      "Ignore": false,
+      "Symbol": "ALGO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RBLS_USDT",
+      "Ignore": false,
+      "Symbol": "RBLS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BVC_USDT",
+      "Ignore": false,
+      "Symbol": "BVC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DORA_USDT",
+      "Ignore": false,
+      "Symbol": "DORA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$MBX_USDT",
+      "Ignore": false,
+      "Symbol": "$MBX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OLE_USDT",
+      "Ignore": false,
+      "Symbol": "OLE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NWC_BTC",
+      "Ignore": false,
+      "Symbol": "NWC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VITE_USDT",
+      "Ignore": false,
+      "Symbol": "VITE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "S2K_USDT",
+      "Ignore": false,
+      "Symbol": "S2K"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SST_USDR",
+      "Ignore": false,
+      "Symbol": "SST"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GST_USDT",
+      "Ignore": false,
+      "Symbol": "GST"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MATIC_BTC",
+      "Ignore": false,
+      "Symbol": "MATIC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SUM_USDT",
+      "Ignore": false,
+      "Symbol": "SUM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SST_USDT",
+      "Ignore": false,
+      "Symbol": "SST"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "REEF_USDT",
+      "Ignore": false,
+      "Symbol": "REEF"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KIBA_USDT",
+      "Ignore": false,
+      "Symbol": "KIBA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PETS_USDT",
+      "Ignore": false,
+      "Symbol": "PETS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CHESS_USDT",
+      "Ignore": false,
+      "Symbol": "CHESS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LIQ_USDT",
+      "Ignore": false,
+      "Symbol": "LIQ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GSX_USDT",
+      "Ignore": false,
+      "Symbol": "GSX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NYM_USDT",
+      "Ignore": false,
+      "Symbol": "NYM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HTO_USDC",
+      "Ignore": false,
+      "Symbol": "HTO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LOOM_BTC",
+      "Ignore": false,
+      "Symbol": "LOOM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STC_USDT",
+      "Ignore": false,
+      "Symbol": "STC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$GM_USDT",
+      "Ignore": false,
+      "Symbol": "$GM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DOT_USDT",
+      "Ignore": false,
+      "Symbol": "DOT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRNDZ_USDT",
+      "Ignore": false,
+      "Symbol": "TRNDZ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CRU_USDT",
+      "Ignore": false,
+      "Symbol": "CRU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SKL_BTC",
+      "Ignore": false,
+      "Symbol": "SKL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PLATO_USDT",
+      "Ignore": false,
+      "Symbol": "PLATO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GMEE_USDT",
+      "Ignore": false,
+      "Symbol": "GMEE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HIGH_USDT",
+      "Ignore": false,
+      "Symbol": "HIGH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ALLEY_USDT",
+      "Ignore": false,
+      "Symbol": "ALLEY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GYC_USDT",
+      "Ignore": false,
+      "Symbol": "GYC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ANONYMOUS_USDT",
+      "Ignore": false,
+      "Symbol": "ANONYMOUS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SMGTO_USDT",
+      "Ignore": false,
+      "Symbol": "SMGTO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LKD_USDT",
+      "Ignore": false,
+      "Symbol": "LKD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GAMINGSHIBA_USDT",
+      "Ignore": false,
+      "Symbol": "GAMINGSHIBA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DEVO_USDT",
+      "Ignore": false,
+      "Symbol": "DEVO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WOO_USDT",
+      "Ignore": false,
+      "Symbol": "WOO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VTHO_USDT",
+      "Ignore": false,
+      "Symbol": "VTHO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LY_USDT",
+      "Ignore": false,
+      "Symbol": "LY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CHZ_USDT",
+      "Ignore": false,
+      "Symbol": "CHZ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TAO_USDT",
+      "Ignore": false,
+      "Symbol": "TAO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GNY_BTC",
+      "Ignore": false,
+      "Symbol": "GNY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PLT_USDT",
+      "Ignore": false,
+      "Symbol": "PLT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ELU_USDT",
+      "Ignore": false,
+      "Symbol": "ELU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ATOM_USDT",
+      "Ignore": false,
+      "Symbol": "ATOM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XLM_USDC",
+      "Ignore": false,
+      "Symbol": "XLM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SYNR_USDT",
+      "Ignore": false,
+      "Symbol": "SYNR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZINU_USDT",
+      "Ignore": false,
+      "Symbol": "ZINU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MEAN_USDT",
+      "Ignore": false,
+      "Symbol": "MEAN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MERGE_USDT",
+      "Ignore": false,
+      "Symbol": "MERGE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GODS_USDT",
+      "Ignore": false,
+      "Symbol": "GODS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LST_USDC",
+      "Ignore": false,
+      "Symbol": "LST"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GLD_USDT",
+      "Ignore": false,
+      "Symbol": "GLD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZPTC_USDC",
+      "Ignore": false,
+      "Symbol": "ZPTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SIDUS_USDT",
+      "Ignore": false,
+      "Symbol": "SIDUS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SAITAMA_USDT",
+      "Ignore": false,
+      "Symbol": "SAITAMA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BONDLY_ETH",
+      "Ignore": false,
+      "Symbol": "BONDLY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XLM_USDT",
+      "Ignore": false,
+      "Symbol": "XLM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GBEX_USDT",
+      "Ignore": false,
+      "Symbol": "GBEX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FXS_USDC",
+      "Ignore": false,
+      "Symbol": "FXS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZLDA_USDT",
+      "Ignore": false,
+      "Symbol": "ZLDA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRN_USDT",
+      "Ignore": false,
+      "Symbol": "TRN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SNX_USDT",
+      "Ignore": false,
+      "Symbol": "SNX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KICK_USDT",
+      "Ignore": false,
+      "Symbol": "KICK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BNT_USDT",
+      "Ignore": false,
+      "Symbol": "BNT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "INJ_USDT",
+      "Ignore": false,
+      "Symbol": "INJ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KTO_USDT",
+      "Ignore": false,
+      "Symbol": "KTO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CRV_USDT",
+      "Ignore": false,
+      "Symbol": "CRV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XDEN_USDT",
+      "Ignore": false,
+      "Symbol": "XDEN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LUXY_USDT",
+      "Ignore": false,
+      "Symbol": "LUXY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FTB_USDT",
+      "Ignore": false,
+      "Symbol": "FTB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AXIS_USDT",
+      "Ignore": false,
+      "Symbol": "AXIS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GODE_USDT",
+      "Ignore": false,
+      "Symbol": "GODE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DOGEKING_USDT",
+      "Ignore": false,
+      "Symbol": "DOGEKING"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ARZ_USDT",
+      "Ignore": false,
+      "Symbol": "ARZ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "C98_USDT",
+      "Ignore": false,
+      "Symbol": "C98"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LOX_USDT",
+      "Ignore": false,
+      "Symbol": "LOX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TOK_USDT",
+      "Ignore": false,
+      "Symbol": "TOK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CRO_USDT",
+      "Ignore": false,
+      "Symbol": "CRO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AZY_USDT",
+      "Ignore": false,
+      "Symbol": "AZY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ASS_USDT",
+      "Ignore": false,
+      "Symbol": "ASS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ADP_USDT",
+      "Ignore": false,
+      "Symbol": "ADP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MSTR_USDT",
+      "Ignore": false,
+      "Symbol": "MSTR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QRX_USDT",
+      "Ignore": false,
+      "Symbol": "QRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "H2ON_USDT",
+      "Ignore": false,
+      "Symbol": "H2ON"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DRAC_USDT",
+      "Ignore": false,
+      "Symbol": "DRAC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MTH_USDT",
+      "Ignore": false,
+      "Symbol": "MTH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "REVV_USDT",
+      "Ignore": false,
+      "Symbol": "REVV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KOL_USDT",
+      "Ignore": false,
+      "Symbol": "KOL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STACK_USDT",
+      "Ignore": false,
+      "Symbol": "STACK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WILD_USDT",
+      "Ignore": false,
+      "Symbol": "WILD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BLXM_USDT",
+      "Ignore": false,
+      "Symbol": "BLXM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRU_USDT",
+      "Ignore": false,
+      "Symbol": "TRU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RACA_USDT",
+      "Ignore": false,
+      "Symbol": "RACA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BLOVELY_USDT",
+      "Ignore": false,
+      "Symbol": "BLOVELY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "IOST_BTC",
+      "Ignore": false,
+      "Symbol": "IOST"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GHD_USDT",
+      "Ignore": false,
+      "Symbol": "GHD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GULF_USDT",
+      "Ignore": false,
+      "Symbol": "GULF"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XSPECTAR_USDT",
+      "Ignore": false,
+      "Symbol": "XSPECTAR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$MESA_USDT",
+      "Ignore": false,
+      "Symbol": "$MESA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WPL_USDT",
+      "Ignore": false,
+      "Symbol": "WPL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CUBE_USDT",
+      "Ignore": false,
+      "Symbol": "CUBE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DOGE2_USDT",
+      "Ignore": false,
+      "Symbol": "DOGE2"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "USDR_USDT",
+      "Ignore": false,
+      "Symbol": "USDR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XBN_USDT",
+      "Ignore": false,
+      "Symbol": "XBN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZYTH_USDT",
+      "Ignore": false,
+      "Symbol": "ZYTH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NSTARS_USDT",
+      "Ignore": false,
+      "Symbol": "NSTARS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MISA_USDT",
+      "Ignore": false,
+      "Symbol": "MISA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XLPG_USDT",
+      "Ignore": false,
+      "Symbol": "XLPG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TUSD_USDC",
+      "Ignore": false,
+      "Symbol": "TUSD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZCX_USDT",
+      "Ignore": false,
+      "Symbol": "ZCX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ARV_USDT",
+      "Ignore": false,
+      "Symbol": "ARV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RACA_USDC",
+      "Ignore": false,
+      "Symbol": "RACA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "APE_USDT",
+      "Ignore": false,
+      "Symbol": "APE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FILM_ETH",
+      "Ignore": false,
+      "Symbol": "FILM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZBC_USDT",
+      "Ignore": false,
+      "Symbol": "ZBC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TUSD_USDT",
+      "Ignore": false,
+      "Symbol": "TUSD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TFUEL_USDT",
+      "Ignore": false,
+      "Symbol": "TFUEL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "APE_USDC",
+      "Ignore": false,
+      "Symbol": "APE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HITOP_USDT",
+      "Ignore": false,
+      "Symbol": "HITOP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "API3_USDT",
+      "Ignore": false,
+      "Symbol": "API3"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LRC_USDT",
+      "Ignore": false,
+      "Symbol": "LRC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "REP_BTC",
+      "Ignore": false,
+      "Symbol": "REP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "APL_USDT",
+      "Ignore": false,
+      "Symbol": "APL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DRSL_USDT",
+      "Ignore": false,
+      "Symbol": "DRSL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHX_USDT",
+      "Ignore": false,
+      "Symbol": "SHX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ALTRU_USDT",
+      "Ignore": false,
+      "Symbol": "ALTRU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TOR_USDT",
+      "Ignore": false,
+      "Symbol": "TOR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DKC_USDT",
+      "Ignore": false,
+      "Symbol": "DKC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DBX_USDT",
+      "Ignore": false,
+      "Symbol": "DBX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SOLVE_USDT",
+      "Ignore": false,
+      "Symbol": "SOLVE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XCN_USDT",
+      "Ignore": false,
+      "Symbol": "XCN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BRT_USDT",
+      "Ignore": false,
+      "Symbol": "BRT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHIRYO_USDT",
+      "Ignore": false,
+      "Symbol": "SHIRYO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UPI_USDT",
+      "Ignore": false,
+      "Symbol": "UPI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FTRB_USDT",
+      "Ignore": false,
+      "Symbol": "FTRB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SG_USDT",
+      "Ignore": false,
+      "Symbol": "SG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MILO_USDT",
+      "Ignore": false,
+      "Symbol": "MILO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DYZ_USDT",
+      "Ignore": false,
+      "Symbol": "DYZ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TOR_USDC",
+      "Ignore": false,
+      "Symbol": "TOR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BMX_USDT",
+      "Ignore": false,
+      "Symbol": "BMX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AMPT_USDT",
+      "Ignore": false,
+      "Symbol": "AMPT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DOGEDIGGER_USDT",
+      "Ignore": false,
+      "Symbol": "DOGEDIGGER"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$LORDZ_USDT",
+      "Ignore": false,
+      "Symbol": "$LORDZ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PPI_USDT",
+      "Ignore": false,
+      "Symbol": "PPI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MINA_USDT",
+      "Ignore": false,
+      "Symbol": "MINA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ARTEQ_USDT",
+      "Ignore": false,
+      "Symbol": "ARTEQ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "IHC_USDT",
+      "Ignore": false,
+      "Symbol": "IHC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GOAL_USDT",
+      "Ignore": false,
+      "Symbol": "GOAL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BTC_USDP",
+      "Ignore": false,
+      "Symbol": "BTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BNB_BTC",
+      "Ignore": false,
+      "Symbol": "BNB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BTC_USDT",
+      "Ignore": false,
+      "Symbol": "BTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LTC_USDT",
+      "Ignore": false,
+      "Symbol": "LTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRADE_USDT",
+      "Ignore": false,
+      "Symbol": "TRADE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WWY_USDT",
+      "Ignore": false,
+      "Symbol": "WWY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HBB_USDT",
+      "Ignore": false,
+      "Symbol": "HBB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "POLS_USDT",
+      "Ignore": false,
+      "Symbol": "POLS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BTC_USDC",
+      "Ignore": false,
+      "Symbol": "BTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "APL_BTC",
+      "Ignore": false,
+      "Symbol": "APL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LTC_USDC",
+      "Ignore": false,
+      "Symbol": "LTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WFAIR_USDT",
+      "Ignore": false,
+      "Symbol": "WFAIR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QLINDO_USDT",
+      "Ignore": false,
+      "Symbol": "QLINDO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GWT_USDT",
+      "Ignore": false,
+      "Symbol": "GWT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UNP_USDT",
+      "Ignore": false,
+      "Symbol": "UNP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TANK_USDT",
+      "Ignore": false,
+      "Symbol": "TANK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MCRT_USDT",
+      "Ignore": false,
+      "Symbol": "MCRT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CELT_USDT",
+      "Ignore": false,
+      "Symbol": "CELT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OJA_USDT",
+      "Ignore": false,
+      "Symbol": "OJA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SYP_USDT",
+      "Ignore": false,
+      "Symbol": "SYP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SLC_USDT",
+      "Ignore": false,
+      "Symbol": "SLC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LED_USDT",
+      "Ignore": false,
+      "Symbol": "LED"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$ORE_USDT",
+      "Ignore": false,
+      "Symbol": "$ORE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GTFO_USDT",
+      "Ignore": false,
+      "Symbol": "GTFO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AFIN_USDT",
+      "Ignore": false,
+      "Symbol": "AFIN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BTT_USDT",
+      "Ignore": false,
+      "Symbol": "BTT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MVRS_USDT",
+      "Ignore": false,
+      "Symbol": "MVRS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LOCUS_USDT",
+      "Ignore": false,
+      "Symbol": "LOCUS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LETSGO_USDT",
+      "Ignore": false,
+      "Symbol": "LETSGO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ELK_USDT",
+      "Ignore": false,
+      "Symbol": "ELK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SRK_BTC",
+      "Ignore": false,
+      "Symbol": "SRK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VCSPERM_USDT",
+      "Ignore": false,
+      "Symbol": "VCSPERM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FUKU_USDT",
+      "Ignore": false,
+      "Symbol": "FUKU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ADXX_USDT",
+      "Ignore": false,
+      "Symbol": "ADXX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SXP_USDT",
+      "Ignore": false,
+      "Symbol": "SXP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NDAU_USDT",
+      "Ignore": false,
+      "Symbol": "NDAU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PTS_USDT",
+      "Ignore": false,
+      "Symbol": "PTS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "IMT_USDT",
+      "Ignore": false,
+      "Symbol": "IMT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BMX_USDC",
+      "Ignore": false,
+      "Symbol": "BMX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SRM_USDT",
+      "Ignore": false,
+      "Symbol": "SRM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HUGO_USDT",
+      "Ignore": false,
+      "Symbol": "HUGO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZEC_USDT",
+      "Ignore": false,
+      "Symbol": "ZEC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DODI_USDT",
+      "Ignore": false,
+      "Symbol": "DODI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QAA_USDT",
+      "Ignore": false,
+      "Symbol": "QAA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RIDE_USDT",
+      "Ignore": false,
+      "Symbol": "RIDE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STI_USDT",
+      "Ignore": false,
+      "Symbol": "STI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRX_USDC",
+      "Ignore": false,
+      "Symbol": "TRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MKR_BTC",
+      "Ignore": false,
+      "Symbol": "MKR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ACK_USDT",
+      "Ignore": false,
+      "Symbol": "ACK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SEON_USDT",
+      "Ignore": false,
+      "Symbol": "SEON"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRX_USDT",
+      "Ignore": false,
+      "Symbol": "TRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STREETH_USDT",
+      "Ignore": false,
+      "Symbol": "STREETH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LON_USDT",
+      "Ignore": false,
+      "Symbol": "LON"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LTC_BTC",
+      "Ignore": false,
+      "Symbol": "LTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DOGE_USDT",
+      "Ignore": false,
+      "Symbol": "DOGE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ISP_USDT",
+      "Ignore": false,
+      "Symbol": "ISP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BUY_USDT",
+      "Ignore": false,
+      "Symbol": "BUY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QUACK_USDT",
+      "Ignore": false,
+      "Symbol": "QUACK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$CC_USDT",
+      "Ignore": false,
+      "Symbol": "$CC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QUICK_USDT",
+      "Ignore": false,
+      "Symbol": "QUICK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EUROC_USDC",
+      "Ignore": false,
+      "Symbol": "EUROC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GW_USDT",
+      "Ignore": false,
+      "Symbol": "GW"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZIL_BTC",
+      "Ignore": false,
+      "Symbol": "ZIL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BICO_USDT",
+      "Ignore": false,
+      "Symbol": "BICO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EOS_BTC",
+      "Ignore": false,
+      "Symbol": "EOS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UNIC_USDT",
+      "Ignore": false,
+      "Symbol": "UNIC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KLAY_USDT",
+      "Ignore": false,
+      "Symbol": "KLAY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BCH_USDT",
+      "Ignore": false,
+      "Symbol": "BCH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ADAO_USDT",
+      "Ignore": false,
+      "Symbol": "ADAO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BLOK_USDT",
+      "Ignore": false,
+      "Symbol": "BLOK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SAVG_USDT",
+      "Ignore": false,
+      "Symbol": "SAVG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DBD_USDT",
+      "Ignore": false,
+      "Symbol": "DBD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TON_USDT",
+      "Ignore": false,
+      "Symbol": "TON"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EUM_ETH",
+      "Ignore": false,
+      "Symbol": "EUM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MEVR_USDT",
+      "Ignore": false,
+      "Symbol": "MEVR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MINIDOGE_USDT",
+      "Ignore": false,
+      "Symbol": "MINIDOGE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "IMC_USDT",
+      "Ignore": false,
+      "Symbol": "IMC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BMX_ETH",
+      "Ignore": false,
+      "Symbol": "BMX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WAS_USDT",
+      "Ignore": false,
+      "Symbol": "WAS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ARIA_USDC",
+      "Ignore": false,
+      "Symbol": "ARIA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LAT_USDT",
+      "Ignore": false,
+      "Symbol": "LAT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ERG_USDT",
+      "Ignore": false,
+      "Symbol": "ERG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VSOL_USDT",
+      "Ignore": false,
+      "Symbol": "VSOL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CELO_USDT",
+      "Ignore": false,
+      "Symbol": "CELO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZRX_BTC",
+      "Ignore": false,
+      "Symbol": "ZRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ACYC_USDT",
+      "Ignore": false,
+      "Symbol": "ACYC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SAUNA_USDT",
+      "Ignore": false,
+      "Symbol": "SAUNA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DIA_USDT",
+      "Ignore": false,
+      "Symbol": "DIA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AMC_USDT",
+      "Ignore": false,
+      "Symbol": "AMC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LOOT_USDT",
+      "Ignore": false,
+      "Symbol": "LOOT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PIZA_USDT",
+      "Ignore": false,
+      "Symbol": "PIZA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HEC_USDT",
+      "Ignore": false,
+      "Symbol": "HEC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "POR_USDT",
+      "Ignore": false,
+      "Symbol": "POR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EOS_USDT",
+      "Ignore": false,
+      "Symbol": "EOS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GNO_USDT",
+      "Ignore": false,
+      "Symbol": "GNO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BOT_USDT",
+      "Ignore": false,
+      "Symbol": "BOT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LOOKS_USDT",
+      "Ignore": false,
+      "Symbol": "LOOKS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "3ULL_USDT",
+      "Ignore": false,
+      "Symbol": "3ULL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SQUIDGROW_USDT",
+      "Ignore": false,
+      "Symbol": "SQUIDGROW"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BAS_USDT",
+      "Ignore": false,
+      "Symbol": "BAS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BRG_USDT",
+      "Ignore": false,
+      "Symbol": "BRG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DOGEDASH_USDT",
+      "Ignore": false,
+      "Symbol": "DOGEDASH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FAKT_USDT",
+      "Ignore": false,
+      "Symbol": "FAKT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MBX_USDT",
+      "Ignore": false,
+      "Symbol": "MBX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ATOM_BTC",
+      "Ignore": false,
+      "Symbol": "ATOM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UFARM_USDT",
+      "Ignore": false,
+      "Symbol": "UFARM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UBX_USDT",
+      "Ignore": false,
+      "Symbol": "UBX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HMT_USDT",
+      "Ignore": false,
+      "Symbol": "HMT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LPT_USDT",
+      "Ignore": false,
+      "Symbol": "LPT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SAFEMONEY_USDT",
+      "Ignore": false,
+      "Symbol": "SAFEMONEY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RAVE_USDT",
+      "Ignore": false,
+      "Symbol": "RAVE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WBTC_USDT",
+      "Ignore": false,
+      "Symbol": "WBTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "REVO_USDT",
+      "Ignore": false,
+      "Symbol": "REVO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FINA_USDT",
+      "Ignore": false,
+      "Symbol": "FINA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SPELL_USDT",
+      "Ignore": false,
+      "Symbol": "SPELL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "APU_USDT",
+      "Ignore": false,
+      "Symbol": "APU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AERO_USDT",
+      "Ignore": false,
+      "Symbol": "AERO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "USDD_USDC",
+      "Ignore": false,
+      "Symbol": "USDD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BITCI_USDT",
+      "Ignore": false,
+      "Symbol": "BITCI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QTUM_BTC",
+      "Ignore": false,
+      "Symbol": "QTUM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DOGE_USDC",
+      "Ignore": false,
+      "Symbol": "DOGE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DCB_USDT",
+      "Ignore": false,
+      "Symbol": "DCB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SLG_USDT",
+      "Ignore": false,
+      "Symbol": "SLG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ATG_USDT",
+      "Ignore": false,
+      "Symbol": "ATG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MVP_USDT",
+      "Ignore": false,
+      "Symbol": "MVP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "USDD_USDT",
+      "Ignore": false,
+      "Symbol": "USDD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UOS_USDT",
+      "Ignore": false,
+      "Symbol": "UOS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DDOGE_USDT",
+      "Ignore": false,
+      "Symbol": "DDOGE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MSOL_USDC",
+      "Ignore": false,
+      "Symbol": "MSOL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TLOS_USDT",
+      "Ignore": false,
+      "Symbol": "TLOS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EOS_USDC",
+      "Ignore": false,
+      "Symbol": "EOS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SPHRI_USDT",
+      "Ignore": false,
+      "Symbol": "SPHRI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BMFLOKI_USDT",
+      "Ignore": false,
+      "Symbol": "BMFLOKI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OMI_USDT",
+      "Ignore": false,
+      "Symbol": "OMI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NAFTY_USDT",
+      "Ignore": false,
+      "Symbol": "NAFTY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "IDNA_USDT",
+      "Ignore": false,
+      "Symbol": "IDNA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MONI_USDT",
+      "Ignore": false,
+      "Symbol": "MONI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OVR_USDT",
+      "Ignore": false,
+      "Symbol": "OVR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BRN_USDT",
+      "Ignore": false,
+      "Symbol": "BRN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GPCX_USDT",
+      "Ignore": false,
+      "Symbol": "GPCX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VSP_USDT",
+      "Ignore": false,
+      "Symbol": "VSP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DCASH_USDT",
+      "Ignore": false,
+      "Symbol": "DCASH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CARR_USDT",
+      "Ignore": false,
+      "Symbol": "CARR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BOBA_USDT",
+      "Ignore": false,
+      "Symbol": "BOBA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FUEL_USDT",
+      "Ignore": false,
+      "Symbol": "FUEL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SUN_USDT",
+      "Ignore": false,
+      "Symbol": "SUN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SMD_USDT",
+      "Ignore": false,
+      "Symbol": "SMD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GOC_ETH",
+      "Ignore": false,
+      "Symbol": "GOC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MVG_USDT",
+      "Ignore": false,
+      "Symbol": "MVG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RBIF_USDT",
+      "Ignore": false,
+      "Symbol": "RBIF"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZED_USDT",
+      "Ignore": false,
+      "Symbol": "ZED"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BONDLY_USDT",
+      "Ignore": false,
+      "Symbol": "BONDLY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PLENTYCOIN_ETH",
+      "Ignore": false,
+      "Symbol": "PLENTYCOIN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LABS_USDT",
+      "Ignore": false,
+      "Symbol": "LABS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AAVE_USDT",
+      "Ignore": false,
+      "Symbol": "AAVE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RADAR_USDT",
+      "Ignore": false,
+      "Symbol": "RADAR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TIGER_USDT",
+      "Ignore": false,
+      "Symbol": "TIGER"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XODEX_USDT",
+      "Ignore": false,
+      "Symbol": "XODEX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GSX_ETH",
+      "Ignore": false,
+      "Symbol": "GSX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WT_USDT",
+      "Ignore": false,
+      "Symbol": "WT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GET_USDT",
+      "Ignore": false,
+      "Symbol": "GET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LITH_USDT",
+      "Ignore": false,
+      "Symbol": "LITH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MYNE_USDT",
+      "Ignore": false,
+      "Symbol": "MYNE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TURBO_USDT",
+      "Ignore": false,
+      "Symbol": "TURBO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BGC_USDT",
+      "Ignore": false,
+      "Symbol": "BGC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NUGGET_USDT",
+      "Ignore": false,
+      "Symbol": "NUGGET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MELON_USDT",
+      "Ignore": false,
+      "Symbol": "MELON"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$HAPPY_USDT",
+      "Ignore": false,
+      "Symbol": "$HAPPY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DUET_USDT",
+      "Ignore": false,
+      "Symbol": "DUET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LDO_USDC",
+      "Ignore": false,
+      "Symbol": "LDO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "JST_USDT",
+      "Ignore": false,
+      "Symbol": "JST"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NCT_USDT",
+      "Ignore": false,
+      "Symbol": "NCT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AR_USDT",
+      "Ignore": false,
+      "Symbol": "AR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SPIN_USDT",
+      "Ignore": false,
+      "Symbol": "SPIN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SWAN_USDT",
+      "Ignore": false,
+      "Symbol": "SWAN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "JULD_USDT",
+      "Ignore": false,
+      "Symbol": "JULD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BTCPAY_USDT",
+      "Ignore": false,
+      "Symbol": "BTCPAY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "REEF_ETH",
+      "Ignore": false,
+      "Symbol": "REEF"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VHC_USDT",
+      "Ignore": false,
+      "Symbol": "VHC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XRPAYNET_USDT",
+      "Ignore": false,
+      "Symbol": "XRPAYNET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EWT_USDT",
+      "Ignore": false,
+      "Symbol": "EWT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HYDRA_USDT",
+      "Ignore": false,
+      "Symbol": "HYDRA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FOXV2_USDT",
+      "Ignore": false,
+      "Symbol": "FOXV2"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STEP_USDT",
+      "Ignore": false,
+      "Symbol": "STEP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HV2_USDT",
+      "Ignore": false,
+      "Symbol": "HV2"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BLP_USDT",
+      "Ignore": false,
+      "Symbol": "BLP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LIKE_USDT",
+      "Ignore": false,
+      "Symbol": "LIKE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VITE_BTC",
+      "Ignore": false,
+      "Symbol": "VITE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "COMP_USDT",
+      "Ignore": false,
+      "Symbol": "COMP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BAL_USDT",
+      "Ignore": false,
+      "Symbol": "BAL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$PAC_USDT",
+      "Ignore": false,
+      "Symbol": "$PAC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "IMX_USDT",
+      "Ignore": false,
+      "Symbol": "IMX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EFI_USDT",
+      "Ignore": false,
+      "Symbol": "EFI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HOD_USDT",
+      "Ignore": false,
+      "Symbol": "HOD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MESA_USDT",
+      "Ignore": false,
+      "Symbol": "MESA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TOWER_USDT",
+      "Ignore": false,
+      "Symbol": "TOWER"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WCSOV_ETH",
+      "Ignore": false,
+      "Symbol": "WCSOV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MOOV_USDT",
+      "Ignore": false,
+      "Symbol": "MOOV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BABYDOGE_USDT",
+      "Ignore": false,
+      "Symbol": "BABYDOGE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ETC_USDT",
+      "Ignore": false,
+      "Symbol": "ETC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CHICKS_USDT",
+      "Ignore": false,
+      "Symbol": "CHICKS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EARN_USDT",
+      "Ignore": false,
+      "Symbol": "EARN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WELT_USDT",
+      "Ignore": false,
+      "Symbol": "WELT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KISHU_USDT",
+      "Ignore": false,
+      "Symbol": "KISHU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MANC_USDT",
+      "Ignore": false,
+      "Symbol": "MANC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BPLC_USDT",
+      "Ignore": false,
+      "Symbol": "BPLC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PIE_USDT",
+      "Ignore": false,
+      "Symbol": "PIE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XTZ_USDT",
+      "Ignore": false,
+      "Symbol": "XTZ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LILFLOKI_USDT",
+      "Ignore": false,
+      "Symbol": "LILFLOKI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FYN_USDT",
+      "Ignore": false,
+      "Symbol": "FYN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BBANK_USDT",
+      "Ignore": false,
+      "Symbol": "BBANK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SMH_BTC",
+      "Ignore": false,
+      "Symbol": "SMH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VET_BTC",
+      "Ignore": false,
+      "Symbol": "VET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EAI_USDT",
+      "Ignore": false,
+      "Symbol": "EAI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KALI_USDT",
+      "Ignore": false,
+      "Symbol": "KALI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OMG_BTC",
+      "Ignore": false,
+      "Symbol": "OMG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BRWL_USDT",
+      "Ignore": false,
+      "Symbol": "BRWL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VOLT_USDT",
+      "Ignore": false,
+      "Symbol": "VOLT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NWC_USDT",
+      "Ignore": false,
+      "Symbol": "NWC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TORG_USDT",
+      "Ignore": false,
+      "Symbol": "TORG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ATHENAS_USDT",
+      "Ignore": false,
+      "Symbol": "ATHENAS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BIT_USDT",
+      "Ignore": false,
+      "Symbol": "BIT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DINGO_USDT",
+      "Ignore": false,
+      "Symbol": "DINGO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ONT_BTC",
+      "Ignore": false,
+      "Symbol": "ONT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CHEQ_USDT",
+      "Ignore": false,
+      "Symbol": "CHEQ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BP_USDT",
+      "Ignore": false,
+      "Symbol": "BP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHR_BTC",
+      "Ignore": false,
+      "Symbol": "SHR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZENITH_USDT",
+      "Ignore": false,
+      "Symbol": "ZENITH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AKITA_USDT",
+      "Ignore": false,
+      "Symbol": "AKITA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GALA_USDC",
+      "Ignore": false,
+      "Symbol": "GALA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PERP_USDT",
+      "Ignore": false,
+      "Symbol": "PERP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CHECKR_USDT",
+      "Ignore": false,
+      "Symbol": "CHECKR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AURORA_USDT",
+      "Ignore": false,
+      "Symbol": "AURORA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SLRR_USDT",
+      "Ignore": false,
+      "Symbol": "SLRR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KUBE_USDT",
+      "Ignore": false,
+      "Symbol": "KUBE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MMETA_USDT",
+      "Ignore": false,
+      "Symbol": "MMETA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ANML_USDT",
+      "Ignore": false,
+      "Symbol": "ANML"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GALA_USDT",
+      "Ignore": false,
+      "Symbol": "GALA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PC_USDT",
+      "Ignore": false,
+      "Symbol": "PC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CHEDDA_USDT",
+      "Ignore": false,
+      "Symbol": "CHEDDA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BERRY_USDT",
+      "Ignore": false,
+      "Symbol": "BERRY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BSFM_USDT",
+      "Ignore": false,
+      "Symbol": "BSFM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RIM_USDT",
+      "Ignore": false,
+      "Symbol": "RIM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NIFT_USDT",
+      "Ignore": false,
+      "Symbol": "NIFT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "1INCH_USDT",
+      "Ignore": false,
+      "Symbol": "1INCH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LSP_USDT",
+      "Ignore": false,
+      "Symbol": "LSP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GAL_USDT",
+      "Ignore": false,
+      "Symbol": "GAL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RVLT_USDT",
+      "Ignore": false,
+      "Symbol": "RVLT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OOE_USDT",
+      "Ignore": false,
+      "Symbol": "OOE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MASK_USDT",
+      "Ignore": false,
+      "Symbol": "MASK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PERI_USDT",
+      "Ignore": false,
+      "Symbol": "PERI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FRR_USDT",
+      "Ignore": false,
+      "Symbol": "FRR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AVAX_USDT",
+      "Ignore": false,
+      "Symbol": "AVAX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SRCX_USDT",
+      "Ignore": false,
+      "Symbol": "SRCX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WGC_USDT",
+      "Ignore": false,
+      "Symbol": "WGC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QOM_USDT",
+      "Ignore": false,
+      "Symbol": "QOM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KLV_USDT",
+      "Ignore": false,
+      "Symbol": "KLV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WGC_ETH",
+      "Ignore": false,
+      "Symbol": "WGC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CCT_USDT",
+      "Ignore": false,
+      "Symbol": "CCT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DODO_USDT",
+      "Ignore": false,
+      "Symbol": "DODO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XLM_BTC",
+      "Ignore": false,
+      "Symbol": "XLM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CAKE_USDT",
+      "Ignore": false,
+      "Symbol": "CAKE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "eRSDL_ETH",
+      "Ignore": false,
+      "Symbol": "eRSDL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "JAM_USDT",
+      "Ignore": false,
+      "Symbol": "JAM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MATH_USDT",
+      "Ignore": false,
+      "Symbol": "MATH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LUNG_USDT",
+      "Ignore": false,
+      "Symbol": "LUNG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EGC_USDT",
+      "Ignore": false,
+      "Symbol": "EGC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PMXX_USDC",
+      "Ignore": false,
+      "Symbol": "PMXX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SWU_USDT",
+      "Ignore": false,
+      "Symbol": "SWU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PKR_USDT",
+      "Ignore": false,
+      "Symbol": "PKR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZRX_USDT",
+      "Ignore": false,
+      "Symbol": "ZRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "POLK_USDT",
+      "Ignore": false,
+      "Symbol": "POLK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BAND_USDT",
+      "Ignore": false,
+      "Symbol": "BAND"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SPAY_USDT",
+      "Ignore": false,
+      "Symbol": "SPAY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VICA_USDT",
+      "Ignore": false,
+      "Symbol": "VICA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UPO_USDT",
+      "Ignore": false,
+      "Symbol": "UPO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DAOVC_USDT",
+      "Ignore": false,
+      "Symbol": "DAOVC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TERN_USDT",
+      "Ignore": false,
+      "Symbol": "TERN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LARIX_USDT",
+      "Ignore": false,
+      "Symbol": "LARIX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LAYER_USDT",
+      "Ignore": false,
+      "Symbol": "LAYER"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "G_USDT",
+      "Ignore": false,
+      "Symbol": "G"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "THETA_USDT",
+      "Ignore": false,
+      "Symbol": "THETA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DAO_USDT",
+      "Ignore": false,
+      "Symbol": "DAO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BTU_USDT",
+      "Ignore": false,
+      "Symbol": "BTU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GOMT_USDT",
+      "Ignore": false,
+      "Symbol": "GOMT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NSUR_USDT",
+      "Ignore": false,
+      "Symbol": "NSUR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DEP_USDT",
+      "Ignore": false,
+      "Symbol": "DEP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SPHYNX_USDT",
+      "Ignore": false,
+      "Symbol": "SPHYNX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "YARL_USDT",
+      "Ignore": false,
+      "Symbol": "YARL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NULS_USDT",
+      "Ignore": false,
+      "Symbol": "NULS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HOP_USDT",
+      "Ignore": false,
+      "Symbol": "HOP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GFCE_USDT",
+      "Ignore": false,
+      "Symbol": "GFCE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NEPT_USDT",
+      "Ignore": false,
+      "Symbol": "NEPT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ZGD_USDT",
+      "Ignore": false,
+      "Symbol": "ZGD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XY_USDT",
+      "Ignore": false,
+      "Symbol": "XY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AUDT_USDT",
+      "Ignore": false,
+      "Symbol": "AUDT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ROCK_USDT",
+      "Ignore": false,
+      "Symbol": "ROCK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STG_USDT",
+      "Ignore": false,
+      "Symbol": "STG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BUSD_USDT",
+      "Ignore": false,
+      "Symbol": "BUSD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XWG_USDT",
+      "Ignore": false,
+      "Symbol": "XWG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LPY_USDT",
+      "Ignore": false,
+      "Symbol": "LPY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "REN_USDT",
+      "Ignore": false,
+      "Symbol": "REN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DG_USDT",
+      "Ignore": false,
+      "Symbol": "DG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SRK_ETH",
+      "Ignore": false,
+      "Symbol": "SRK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MOVEZ_USDT",
+      "Ignore": false,
+      "Symbol": "MOVEZ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NEO_ETH",
+      "Ignore": false,
+      "Symbol": "NEO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BUSD_USDC",
+      "Ignore": false,
+      "Symbol": "BUSD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FEN_USDT",
+      "Ignore": false,
+      "Symbol": "FEN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EHX_USDT",
+      "Ignore": false,
+      "Symbol": "EHX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DAPSW_USDT",
+      "Ignore": false,
+      "Symbol": "DAPSW"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RARI_USDT",
+      "Ignore": false,
+      "Symbol": "RARI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DYDX_USDT",
+      "Ignore": false,
+      "Symbol": "DYDX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ATLAS_USDT",
+      "Ignore": false,
+      "Symbol": "ATLAS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DOGECOIN_USDT",
+      "Ignore": false,
+      "Symbol": "DOGECOIN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRX_BTC",
+      "Ignore": false,
+      "Symbol": "TRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HT_USDT",
+      "Ignore": false,
+      "Symbol": "HT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LYO_USDT",
+      "Ignore": false,
+      "Symbol": "LYO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GDT_USDT",
+      "Ignore": false,
+      "Symbol": "GDT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FILM_USDT",
+      "Ignore": false,
+      "Symbol": "FILM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BAT_USDT",
+      "Ignore": false,
+      "Symbol": "BAT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LTNM_USDT",
+      "Ignore": false,
+      "Symbol": "LTNM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "USDC_USDT",
+      "Ignore": false,
+      "Symbol": "USDC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LIFE_USDT",
+      "Ignore": false,
+      "Symbol": "LIFE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ICP_USDT",
+      "Ignore": false,
+      "Symbol": "ICP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OCC_USDT",
+      "Ignore": false,
+      "Symbol": "OCC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "E$P_USDT",
+      "Ignore": false,
+      "Symbol": "E$P"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DVRS_USDT",
+      "Ignore": false,
+      "Symbol": "DVRS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "P202_USDT",
+      "Ignore": false,
+      "Symbol": "P202"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VERA_USDT",
+      "Ignore": false,
+      "Symbol": "VERA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MEX_USDT",
+      "Ignore": false,
+      "Symbol": "MEX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "YGG_USDT",
+      "Ignore": false,
+      "Symbol": "YGG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HI_USDT",
+      "Ignore": false,
+      "Symbol": "HI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PLANETS_USDT",
+      "Ignore": false,
+      "Symbol": "PLANETS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ARTRINO_USDT",
+      "Ignore": false,
+      "Symbol": "ARTRINO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ANC_USDT",
+      "Ignore": false,
+      "Symbol": "ANC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AQUAGOAT_USDT",
+      "Ignore": false,
+      "Symbol": "AQUAGOAT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "Yinbi_USDT",
+      "Ignore": false,
+      "Symbol": "Yinbi"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FND_USDT",
+      "Ignore": false,
+      "Symbol": "FND"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LANC_USDT",
+      "Ignore": false,
+      "Symbol": "LANC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OM_USDT",
+      "Ignore": false,
+      "Symbol": "OM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UNN_USDT",
+      "Ignore": false,
+      "Symbol": "UNN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DEFC_USDT",
+      "Ignore": false,
+      "Symbol": "DEFC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PCL_USDT",
+      "Ignore": false,
+      "Symbol": "PCL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EQ_USDT",
+      "Ignore": false,
+      "Symbol": "EQ"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LBC_USDT",
+      "Ignore": false,
+      "Symbol": "LBC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BEPRO_USDT",
+      "Ignore": false,
+      "Symbol": "BEPRO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NEO_USDT",
+      "Ignore": false,
+      "Symbol": "NEO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BTC_DAI",
+      "Ignore": false,
+      "Symbol": "BTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CIRUS_USDT",
+      "Ignore": false,
+      "Symbol": "CIRUS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "REPO_BTC",
+      "Ignore": false,
+      "Symbol": "REPO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MHUNT_USDT",
+      "Ignore": false,
+      "Symbol": "MHUNT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UMA_USDT",
+      "Ignore": false,
+      "Symbol": "UMA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ENS_USDT",
+      "Ignore": false,
+      "Symbol": "ENS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GBT_USDT",
+      "Ignore": false,
+      "Symbol": "GBT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GSX_BTC",
+      "Ignore": false,
+      "Symbol": "GSX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VXL_USDT",
+      "Ignore": false,
+      "Symbol": "VXL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OXP_USDT",
+      "Ignore": false,
+      "Symbol": "OXP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TBC_USDT",
+      "Ignore": false,
+      "Symbol": "TBC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VEMP_USDT",
+      "Ignore": false,
+      "Symbol": "VEMP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LITX_USDT",
+      "Ignore": false,
+      "Symbol": "LITX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PKN_USDT",
+      "Ignore": false,
+      "Symbol": "PKN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "IDO_USDT",
+      "Ignore": false,
+      "Symbol": "IDO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FITFI_USDT",
+      "Ignore": false,
+      "Symbol": "FITFI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RCG_USDT",
+      "Ignore": false,
+      "Symbol": "RCG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TRAC_BTC",
+      "Ignore": false,
+      "Symbol": "TRAC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HZM_USDT",
+      "Ignore": false,
+      "Symbol": "HZM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WRX_USDT",
+      "Ignore": false,
+      "Symbol": "WRX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RVF_USDT",
+      "Ignore": false,
+      "Symbol": "RVF"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EDDA_USDT",
+      "Ignore": false,
+      "Symbol": "EDDA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CDTC_USDT",
+      "Ignore": false,
+      "Symbol": "CDTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "10SET_USDT",
+      "Ignore": false,
+      "Symbol": "10SET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WQT_USDT",
+      "Ignore": false,
+      "Symbol": "WQT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EUM_BTC",
+      "Ignore": false,
+      "Symbol": "EUM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VLTY_USDT",
+      "Ignore": false,
+      "Symbol": "VLTY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RAY_USDT",
+      "Ignore": false,
+      "Symbol": "RAY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BABY_USDT",
+      "Ignore": false,
+      "Symbol": "BABY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RADIO_USDT",
+      "Ignore": false,
+      "Symbol": "RADIO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RTT_USDT",
+      "Ignore": false,
+      "Symbol": "RTT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ADA_USDC",
+      "Ignore": false,
+      "Symbol": "ADA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BX_USDT",
+      "Ignore": false,
+      "Symbol": "BX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WE_USDT",
+      "Ignore": false,
+      "Symbol": "WE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LEASH_USDT",
+      "Ignore": false,
+      "Symbol": "LEASH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DVDX_USDT",
+      "Ignore": false,
+      "Symbol": "DVDX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NAKA_USDT",
+      "Ignore": false,
+      "Symbol": "NAKA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DOGECOLA_USDT",
+      "Ignore": false,
+      "Symbol": "DOGECOLA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LAIKA_USDT",
+      "Ignore": false,
+      "Symbol": "LAIKA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STRM_USDT",
+      "Ignore": false,
+      "Symbol": "STRM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CFX_USDT",
+      "Ignore": false,
+      "Symbol": "CFX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GVR_USDT",
+      "Ignore": false,
+      "Symbol": "GVR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LOV_USDT",
+      "Ignore": false,
+      "Symbol": "LOV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PLCU_USDT",
+      "Ignore": false,
+      "Symbol": "PLCU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HUMP_USDT",
+      "Ignore": false,
+      "Symbol": "HUMP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MLX_USDT",
+      "Ignore": false,
+      "Symbol": "MLX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LFW_USDT",
+      "Ignore": false,
+      "Symbol": "LFW"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ACA_USDT",
+      "Ignore": false,
+      "Symbol": "ACA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HST_USDT",
+      "Ignore": false,
+      "Symbol": "HST"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DES_USDT",
+      "Ignore": false,
+      "Symbol": "DES"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CKT_USDT",
+      "Ignore": false,
+      "Symbol": "CKT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WELD_USDT",
+      "Ignore": false,
+      "Symbol": "WELD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HOGE_USDT",
+      "Ignore": false,
+      "Symbol": "HOGE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NCT_ETH",
+      "Ignore": false,
+      "Symbol": "NCT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GMEX_USDT",
+      "Ignore": false,
+      "Symbol": "GMEX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EUL_USDT",
+      "Ignore": false,
+      "Symbol": "EUL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XCN_BTC",
+      "Ignore": false,
+      "Symbol": "XCN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MSHOT_USDT",
+      "Ignore": false,
+      "Symbol": "MSHOT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "EMPIRE_USDT",
+      "Ignore": false,
+      "Symbol": "EMPIRE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ACH_USDT",
+      "Ignore": false,
+      "Symbol": "ACH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PTX_USDT",
+      "Ignore": false,
+      "Symbol": "PTX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BERS_USDT",
+      "Ignore": false,
+      "Symbol": "BERS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ELVN_USDT",
+      "Ignore": false,
+      "Symbol": "ELVN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GERA_BTC",
+      "Ignore": false,
+      "Symbol": "GERA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "$DFI_USDT",
+      "Ignore": false,
+      "Symbol": "$DFI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CLASS_USDT",
+      "Ignore": false,
+      "Symbol": "CLASS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "REFLEX_USDT",
+      "Ignore": false,
+      "Symbol": "REFLEX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STA_USDT",
+      "Ignore": false,
+      "Symbol": "STA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "INDI_USDT",
+      "Ignore": false,
+      "Symbol": "INDI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OCEAN_USDT",
+      "Ignore": false,
+      "Symbol": "OCEAN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BSV_USDT",
+      "Ignore": false,
+      "Symbol": "BSV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "APL_ETH",
+      "Ignore": false,
+      "Symbol": "APL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CELR_USDT",
+      "Ignore": false,
+      "Symbol": "CELR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SAND_USDT",
+      "Ignore": false,
+      "Symbol": "SAND"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LINA_USDT",
+      "Ignore": false,
+      "Symbol": "LINA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ILV_USDT",
+      "Ignore": false,
+      "Symbol": "ILV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VPAD_USDT",
+      "Ignore": false,
+      "Symbol": "VPAD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CHECK_USDT",
+      "Ignore": false,
+      "Symbol": "CHECK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WSOW_USDT",
+      "Ignore": false,
+      "Symbol": "WSOW"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "G1X_USDT",
+      "Ignore": false,
+      "Symbol": "G1X"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FIMI_USDT",
+      "Ignore": false,
+      "Symbol": "FIMI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ADA_USDT",
+      "Ignore": false,
+      "Symbol": "ADA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PORNROCKET_USDT",
+      "Ignore": false,
+      "Symbol": "PORNROCKET"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "METIS_USDT",
+      "Ignore": false,
+      "Symbol": "METIS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "R1_USDT",
+      "Ignore": false,
+      "Symbol": "R1"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FEAR_USDT",
+      "Ignore": false,
+      "Symbol": "FEAR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "YOOSHI_USDT",
+      "Ignore": false,
+      "Symbol": "YOOSHI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QANX_USDT",
+      "Ignore": false,
+      "Symbol": "QANX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "H2O_USDT",
+      "Ignore": false,
+      "Symbol": "H2O"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FFA_USDT",
+      "Ignore": false,
+      "Symbol": "FFA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SKEY_USDT",
+      "Ignore": false,
+      "Symbol": "SKEY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FRONT_USDT",
+      "Ignore": false,
+      "Symbol": "FRONT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LOOBR_USDT",
+      "Ignore": false,
+      "Symbol": "LOOBR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LEOS_USDT",
+      "Ignore": false,
+      "Symbol": "LEOS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UFO_USDT",
+      "Ignore": false,
+      "Symbol": "UFO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NEOM_USDT",
+      "Ignore": false,
+      "Symbol": "NEOM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XDNA_USDT",
+      "Ignore": false,
+      "Symbol": "XDNA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FUSE_USDT",
+      "Ignore": false,
+      "Symbol": "FUSE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RTC_USDT",
+      "Ignore": false,
+      "Symbol": "RTC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CULT_USDT",
+      "Ignore": false,
+      "Symbol": "CULT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "YCO_BTC",
+      "Ignore": false,
+      "Symbol": "YCO"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SAND_USDC",
+      "Ignore": false,
+      "Symbol": "SAND"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FAME_USDT",
+      "Ignore": false,
+      "Symbol": "FAME"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ICE_USDT",
+      "Ignore": false,
+      "Symbol": "ICE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HOT_USDT",
+      "Ignore": false,
+      "Symbol": "HOT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BMX_BTC",
+      "Ignore": false,
+      "Symbol": "BMX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ATLAS_USDC",
+      "Ignore": false,
+      "Symbol": "ATLAS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ANN_USDT",
+      "Ignore": false,
+      "Symbol": "ANN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ALICE_USDT",
+      "Ignore": false,
+      "Symbol": "ALICE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FREE_USDT",
+      "Ignore": false,
+      "Symbol": "FREE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "YLDY_USDT",
+      "Ignore": false,
+      "Symbol": "YLDY"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "NYN_USDT",
+      "Ignore": false,
+      "Symbol": "NYN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "XCAD_USDT",
+      "Ignore": false,
+      "Symbol": "XCAD"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LOOP_USDT",
+      "Ignore": false,
+      "Symbol": "LOOP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SCRT_USDT",
+      "Ignore": false,
+      "Symbol": "SCRT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SHINJA(1M)_USDT",
+      "Ignore": false,
+      "Symbol": "SHINJA(1M)"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "DC_USDT",
+      "Ignore": false,
+      "Symbol": "DC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "JRIT_USDT",
+      "Ignore": false,
+      "Symbol": "JRIT"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "IP3_USDT",
+      "Ignore": false,
+      "Symbol": "IP3"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AKN_USDT",
+      "Ignore": false,
+      "Symbol": "AKN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "QI_USDT",
+      "Ignore": false,
+      "Symbol": "QI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BURN_USDT",
+      "Ignore": false,
+      "Symbol": "BURN"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "FWC_USDT",
+      "Ignore": false,
+      "Symbol": "FWC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SLRS_USDT",
+      "Ignore": false,
+      "Symbol": "SLRS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OP_USDT",
+      "Ignore": false,
+      "Symbol": "OP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "GM_USDT",
+      "Ignore": false,
+      "Symbol": "GM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "OP_USDC",
+      "Ignore": false,
+      "Symbol": "OP"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "WEMIX_USDT",
+      "Ignore": false,
+      "Symbol": "WEMIX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LIB_USDT",
+      "Ignore": false,
+      "Symbol": "LIB"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BCH_BTC",
+      "Ignore": false,
+      "Symbol": "BCH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KTX_USDT",
+      "Ignore": false,
+      "Symbol": "KTX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "BTH_USDT",
+      "Ignore": false,
+      "Symbol": "BTH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STARL_USDT",
+      "Ignore": false,
+      "Symbol": "STARL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HBAR_USDT",
+      "Ignore": false,
+      "Symbol": "HBAR"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VINU_USDT",
+      "Ignore": false,
+      "Symbol": "VINU"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "VXV_USDT",
+      "Ignore": false,
+      "Symbol": "VXV"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "CC_USDT",
+      "Ignore": false,
+      "Symbol": "CC"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "STARS_USDT",
+      "Ignore": false,
+      "Symbol": "STARS"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "LINK_USDT",
+      "Ignore": false,
+      "Symbol": "LINK"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "TLM_USDT",
+      "Ignore": false,
+      "Symbol": "TLM"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "RARE_USDT",
+      "Ignore": false,
+      "Symbol": "RARE"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HEAL_USDT",
+      "Ignore": false,
+      "Symbol": "HEAL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ARX_USDT",
+      "Ignore": false,
+      "Symbol": "ARX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "UTG_USDT",
+      "Ignore": false,
+      "Symbol": "UTG"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "AAA_USDT",
+      "Ignore": false,
+      "Symbol": "AAA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "SUSHI_USDT",
+      "Ignore": false,
+      "Symbol": "SUSHI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "HODL_USDT",
+      "Ignore": false,
+      "Symbol": "HODL"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "PLEX_USDT",
+      "Ignore": false,
+      "Symbol": "PLEX"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "ETH_BTC",
+      "Ignore": false,
+      "Symbol": "ETH"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "KARA_USDT",
+      "Ignore": false,
+      "Symbol": "KARA"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MAKI_USDT",
+      "Ignore": false,
+      "Symbol": "MAKI"
+    },
+    {
+      "Exchange": "BitMart",
+      "ForeignName": "MRHB_USDT",
+      "Ignore": false,
+      "Symbol": "MRHB"
+    }
+  ]
+}

--- a/config/exchanges/exchanges.json
+++ b/config/exchanges/exchanges.json
@@ -196,6 +196,19 @@
             "WatchdogDelay": 1200
         },
         {
+            "Name": "BitMart",
+            "Centralized": true,
+            "Bridge": false,
+            "Contract": "",
+            "Blockchain": {
+                "Name": ""
+            },
+            "RestAPI": "https://api-cloud.bitmart.com/spot/v1/",
+            "WsAPI": "wss://ws-manager-compress.bitmart.com/api?protocol=1.1",
+            "pairsAPI": "https://api-cloud.bitmart.com/spot/v1/symbols",
+            "WatchdogDelay": 1200
+        },
+        {
             "Name": "Bitmax",
             "Centralized": true,
             "Bridge": false,

--- a/config/gitcoinverified/BitMart.json
+++ b/config/gitcoinverified/BitMart.json
@@ -1,0 +1,10 @@
+{
+  "Tokens": [
+    {
+      "Symbol": "WBTC",
+      "Exchange": "BitMart",
+      "Blockchain": "Ethereum",
+      "Address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+    }
+  ]
+}

--- a/pkg/dia/Config.go
+++ b/pkg/dia/Config.go
@@ -68,6 +68,7 @@ const (
 	DforceExchange            = "Dforce"
 	ZeroxExchange             = "0x"
 	KyberExchange             = "Kyber"
+	BitMartExchange           = "BitMart"
 	BitMaxExchange            = "Bitmax"
 	MEXCExchange              = "MEXC"
 	CREX24Exchange            = "CREX24"

--- a/pkg/dia/scraper/exchange-scrapers/APIScraper.go
+++ b/pkg/dia/scraper/exchange-scrapers/APIScraper.go
@@ -184,6 +184,8 @@ func NewAPIScraper(exchange string, scrape bool, key string, secret string, relD
 		return NewZeroxScraper(Exchanges[dia.ZeroxExchange], scrape)
 	case dia.KyberExchange:
 		return NewKyberScraper(Exchanges[dia.KyberExchange], scrape)
+	case dia.BitMartExchange:
+		return NewBitMartScraper(Exchanges[dia.BitMartExchange], scrape, relDB)
 	case dia.BitMaxExchange:
 		return NewBitMaxScraper(Exchanges[dia.BitMaxExchange], scrape, relDB)
 	case dia.MEXCExchange:

--- a/pkg/dia/scraper/exchange-scrapers/BitMartScraper.go
+++ b/pkg/dia/scraper/exchange-scrapers/BitMartScraper.go
@@ -1,0 +1,479 @@
+package scrapers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	ws "github.com/gorilla/websocket"
+	"go.uber.org/ratelimit"
+
+	"github.com/diadata-org/diadata/pkg/dia"
+	models "github.com/diadata-org/diadata/pkg/model"
+	"github.com/diadata-org/diadata/pkg/utils"
+)
+
+const (
+	bitMartAPIEndpoint          = "https://api-cloud.bitmart.com/spot/v1"
+	bitMartWSEndpoint           = "wss://ws-manager-compress.bitmart.com/api?protocol=1.1"
+	bitMartSpotTradingSell      = "sell"
+	bitMartSymbolsStatusActive  = "trading"
+	bitMartPingMessage          = "ping"
+	bitMartPongMessage          = "pong"
+	bitMartWSSpotTradingTopic   = "spot/trade"
+	bitMartWSOpSubscribe        = "subscribe"
+	bitMartWSOpUnsubscribe      = "unsubscribe"
+	bitMartRetryAttempts        = 15  // Max consecutive retry attempts until connection fail.
+	bitMartPingInterval         = 15  // Number of seconds between ping messages.
+	bitMartMaxConnections       = 10  // Numbers of connections per IP.
+	bitMartMaxSubsPerConnection = 100 // Subscription limit for each connection.
+)
+
+type BitmartWsRequest struct {
+	Op   string   `json:"op"`
+	Args []string `json:"args"`
+}
+
+type BitmartHttpSymbolsDetailsResponse struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+	Trace   string `json:"trace"`
+	Data    struct {
+		Symbols []struct {
+			Symbol            string `json:"symbol"`
+			SymbolId          int    `json:"symbol_id"`
+			BaseCurrency      string `json:"base_currency"`
+			QuoteCurrency     string `json:"quote_currency"`
+			QuoteIncrement    string `json:"quote_increment"`
+			BaseMinSize       string `json:"base_min_size"`
+			PriceMinPrecision int    `json:"price_min_precision"`
+			PriceMaxPrecision int    `json:"price_max_precision"`
+			Expiration        string `json:"expiration"`
+			MinBuyAmount      string `json:"min_buy_amount"`
+			MinSellAmount     string `json:"min_sell_amount"`
+			TradeStatus       string `json:"trade_status"`
+		} `json:"symbols"`
+	} `json:"data"`
+}
+type BitmartWsTradeResponse struct {
+	Table string `json:"table"`
+	Data  []struct {
+		Symbol       string `json:"symbol"`
+		Price        string `json:"price"`
+		Side         string `json:"side"`
+		Size         string `json:"size"`
+		TimestampSec int    `json:"s_t"`
+	} `json:"data"`
+	ErrorMessage string `json:"errorMessage"`
+	ErrorCode    string `json:"errorCode"`
+	Event        string `json:"event"`
+}
+
+type bitMartPairScraperSet map[*BitMartPairScraper]nothing
+
+// BitMartScraper is a scraper for BitMart
+type BitMartScraper struct {
+	// the websocket connection to the BitMart API
+	wsClient           []*ws.Conn
+	errCount           []int
+	countTopic         []int
+	lastUsedConnection int
+	rl                 ratelimit.Limiter
+	listener           chan *BitmartWsTradeResponse
+	// signaling channels for session initialization and finishing
+	shutdown     chan nothing
+	shutdownDone chan nothing
+	// error handling; err should be read from error(), closed should be read from isClosed()
+	// those two methods implement RW lock
+	// only cleanup method should hold write lock
+	closedMutex sync.RWMutex // don't need to lock on read
+	closed      bool
+	errMutex    sync.RWMutex
+	err         error
+	// used to keep track of trading pairs that we subscribed to
+	// use sync.Maps to concurrently handle multiple pairs
+	pairScrapers      sync.Map // dia.ExchangePair -> bitMartPairScraperSet
+	pairSubscriptions sync.Map // dia.ExchangePair -> int (connection ID)
+	exchangeName      string
+	chanTrades        chan *dia.Trade
+	db                *models.RelDB
+}
+
+// NewBitMartScraper returns a new BitMart scraper
+func NewBitMartScraper(exchange dia.Exchange, scrape bool, relDB *models.RelDB) *BitMartScraper {
+	s := &BitMartScraper{
+		wsClient:     make([]*ws.Conn, bitMartMaxConnections),
+		errCount:     make([]int, bitMartMaxConnections),
+		countTopic:   make([]int, bitMartMaxConnections),
+		rl:           ratelimit.New(100, ratelimit.Per(10*time.Second)),
+		listener:     make(chan *BitmartWsTradeResponse),
+		shutdown:     make(chan nothing),
+		shutdownDone: make(chan nothing),
+		closed:       false,
+		err:          nil,
+		exchangeName: exchange.Name,
+		chanTrades:   make(chan *dia.Trade),
+		db:           relDB,
+	}
+	for i := 0; i < bitMartMaxConnections; i++ {
+		var wsDialer ws.Dialer
+		wsConn, _, err := wsDialer.Dial(bitMartWSEndpoint, nil)
+		if err != nil {
+			println(err.Error())
+		}
+		s.wsClient[i] = wsConn
+	}
+	if scrape {
+		go s.mainLoop()
+	}
+	return s
+}
+
+// Close closes any existing API connections, as well as channels of
+// PairScrapers from calls to ScrapePair
+func (s *BitMartScraper) Close() error {
+	if s.isClosed() {
+		return errors.New("scraper already closed")
+	}
+	s.close()
+	close(s.shutdown)
+	for i := 0; i < bitMartMaxConnections; i++ {
+		err := s.wsClient[i].Close()
+		if err != nil {
+			return fmt.Errorf("Close Error: %s", err.Error())
+		}
+	}
+	<-s.shutdownDone
+	return s.error()
+}
+
+// ScrapePair returns a PairScraper that can be used to get trades for a single pair from the BitMart scraper
+func (s *BitMartScraper) ScrapePair(pair dia.ExchangePair) (PairScraper, error) {
+	if err := s.error(); err != nil {
+		return nil, err
+	}
+	if s.isClosed() {
+		return nil, errors.New("scraper is closed")
+	}
+	ps := &BitMartPairScraper{
+		parent: s,
+		pair:   pair,
+	}
+	pairScrapers, _ := s.pairScrapers.LoadOrStore(pair.ForeignName, bitMartPairScraperSet{})
+	pairScrapers.(bitMartPairScraperSet)[ps] = nothing{}
+	if _, ok := s.pairSubscriptions.Load(pair.ForeignName); !ok {
+		wsIdx := s.lastUsedConnection
+		if cIdx := s.lastUsedConnection; s.countTopic[cIdx] < bitMartMaxSubsPerConnection {
+			wsIdx = cIdx
+		} else {
+			for i := 0; i < bitMartMaxConnections; i++ {
+				if s.countTopic[i] < bitMartMaxSubsPerConnection {
+					wsIdx = i
+				}
+			}
+		}
+		if err := s.subscribe(pair.ForeignName, wsIdx); err != nil {
+			delete(pairScrapers.(bitMartPairScraperSet), ps)
+			return nil, err
+		}
+		s.pairSubscriptions.Store(pair.ForeignName, wsIdx)
+	} else {
+		return nil, fmt.Errorf("pair %s already subscribed", pair.ForeignName)
+	}
+	return ps, nil
+}
+
+// FetchAvailablePairs returns a list with all available trade pairs
+func (s *BitMartScraper) FetchAvailablePairs() (pairs []dia.ExchangePair, err error) {
+	data, _, err := utils.GetRequest(bitMartAPIEndpoint + "/symbols/details")
+	if err != nil {
+		return
+	}
+	var res BitmartHttpSymbolsDetailsResponse
+	err = json.Unmarshal(data, &res)
+	if err == nil {
+		for _, p := range res.Data.Symbols {
+			if p.TradeStatus != bitMartSymbolsStatusActive {
+				continue
+			}
+			pair, err := s.NormalizePair(dia.ExchangePair{
+				Symbol:      p.BaseCurrency,
+				ForeignName: p.Symbol,
+				Exchange:    s.exchangeName,
+			})
+			if err != nil {
+				return nil, err
+			}
+			pairs = append(pairs, pair)
+		}
+	}
+	return pairs, nil
+}
+
+// Channel returns a channel that can be used to receive trades
+func (s *BitMartScraper) Channel() chan *dia.Trade {
+	return s.chanTrades
+}
+
+// TODO: FillSymbolData adds the name to the asset underlying @symbol on BitMart
+func (s *BitMartScraper) FillSymbolData(symbol string) (dia.Asset, error) {
+	return dia.Asset{Symbol: symbol}, nil
+}
+
+// TODO: NormalizePair accounts for the par
+func (s *BitMartScraper) NormalizePair(pair dia.ExchangePair) (dia.ExchangePair, error) {
+	return pair, nil
+}
+
+// BitMartPairScraper implements PairScraper for BitMart
+type BitMartPairScraper struct {
+	parent *BitMartScraper
+	pair   dia.ExchangePair
+	closed bool
+}
+
+// Close stops listening for trades of the pair associated with the BitMart scraper
+func (ps *BitMartPairScraper) Close() error {
+	if ps.closed {
+		return fmt.Errorf("pair %s already unsubscribed", ps.pair.ForeignName)
+	}
+	log.Infof("Closing %s pair scraper...", ps.pair.ForeignName)
+	if err := ps.parent.error(); err != nil {
+		return err
+	}
+	if err := ps.parent.unsubscribe(ps.pair.ForeignName); err != nil {
+		return err
+	}
+	ps.parent.pairSubscriptions.Delete(ps.pair.ForeignName)
+	ps.closed = true
+	return nil
+}
+
+// Error returns an error when the channel Channel() is closed and nil otherwise
+func (ps *BitMartPairScraper) Error() error {
+	return ps.parent.error()
+}
+
+// Pair returns the pair this scraper is subscribed to
+func (ps *BitMartPairScraper) Pair() dia.ExchangePair {
+	return ps.pair
+}
+
+// runs in a goroutine until s is closed
+func (s *BitMartScraper) mainLoop() {
+	defer s.cleanup(nil)
+	defer func() {
+		log.Printf("Shutting down main loop...\n")
+	}()
+	for i := 0; i < bitMartMaxConnections; i++ {
+		go func(idx int) {
+			defer func() {
+				if a := recover(); a != nil {
+					log.Errorf("Work routine end. Recover msg: %+v", a)
+				}
+			}()
+			ticker := time.NewTicker(bitMartPingInterval * time.Second)
+			defer ticker.Stop()
+			for {
+				<-ticker.C
+				if s.isClosed() {
+					return
+				}
+				s.rl.Take()
+				if err := s.wsClient[idx].WriteMessage(ws.TextMessage, []byte(bitMartPingMessage)); err != nil {
+					log.Errorf("Error sending ping: %s", err)
+				}
+			}
+		}(i)
+		go func(idx int) {
+			defer func() {
+				if a := recover(); a != nil {
+					log.Errorf("Receive routine end. Recover msg: %+v", a)
+				}
+			}()
+			for {
+				if s.wsClient[idx] != nil {
+					msgType, msg, err := s.wsClient[idx].ReadMessage()
+					if err != nil {
+						if s.isClosed() || s.errCount[idx] > bitMartRetryAttempts {
+							return
+						}
+						if err := s.retryConnection(idx); err != nil || ws.IsCloseError(err, ws.CloseAbnormalClosure) {
+							continue
+						}
+					}
+					if msgType == ws.TextMessage {
+						if string(msg) == bitMartPongMessage {
+							s.errCount[idx] = 0
+							continue
+						}
+						var subResults BitmartWsTradeResponse
+						if err := json.Unmarshal(msg, &subResults); err != nil {
+							log.Errorf("Response error at connection #%d, err=%s\n", idx, err.Error())
+							s.setError(err)
+							s.errCount[idx]++
+							if err := s.retryConnection(idx); err != nil {
+								continue
+							}
+						}
+						if subResults.ErrorCode != "" {
+							log.Errorf("Error code %s at %s event: %s", subResults.ErrorCode, subResults.Event, subResults.ErrorMessage)
+							s.errCount[idx]++
+							continue
+						}
+						if subResults.Table == bitMartWSSpotTradingTopic {
+							s.errCount[idx] = 0
+							s.listener <- &subResults
+						}
+					}
+				}
+			}
+		}(i)
+	}
+	for {
+		select {
+		case response := <-s.listener:
+			for _, data := range response.Data {
+				var exchangepair dia.ExchangePair
+				volume, _ := strconv.ParseFloat(data.Size, 64)
+				if data.Side == bitMartSpotTradingSell {
+					volume = -volume
+				}
+				price, _ := strconv.ParseFloat(data.Price, 64)
+				time := time.Unix(int64(data.TimestampSec), 0)
+				symbol := strings.Split(data.Symbol, `_`)
+				exchangepair, err := s.db.GetExchangePairCache(s.exchangeName, data.Symbol)
+				if err != nil {
+					log.Error(err)
+				}
+				t := &dia.Trade{
+					Symbol:         symbol[0],
+					Pair:           data.Symbol,
+					Price:          price,
+					Time:           time,
+					Volume:         volume,
+					Source:         s.exchangeName,
+					ForeignTradeID: fmt.Sprintf("%s_%d", data.Symbol, data.TimestampSec),
+					VerifiedPair:   exchangepair.Verified,
+					BaseToken:      exchangepair.UnderlyingPair.BaseToken,
+					QuoteToken:     exchangepair.UnderlyingPair.QuoteToken,
+				}
+				s.chanTrades <- t
+			}
+		case <-s.shutdown:
+			return
+		}
+	}
+}
+
+func (s *BitMartScraper) retryConnection(idx int) error {
+	s.countTopic[idx] = 0
+	log.Errorf("Reconnecting connection #%d...\n", idx)
+	wsConn, _, err := ws.DefaultDialer.Dial(bitMartWSEndpoint, nil)
+	if err != nil {
+		s.errCount[idx]++
+		return err
+	}
+	s.wsClient[idx] = wsConn
+	subs := make([]string, 0)
+	s.pairSubscriptions.Range(func(k, v interface{}) bool {
+		if v.(int) == idx {
+			if foreignName := k.(string); foreignName != "" {
+				subs = append(subs, foreignName)
+			}
+		}
+		return true
+	})
+	for _, foreignName := range subs {
+		if err = s.subscribe(foreignName, idx); err != nil {
+			break
+		}
+	}
+	if err != nil {
+		log.Errorf("Recovering %d error., err=%s\n", idx, err.Error())
+		s.setError(err)
+		s.errCount[idx]++
+		return err
+	}
+	log.Infof("Successfully reconnected connection %d., errCount=%d", idx, s.errCount[idx])
+	return nil
+}
+
+// closes all connected PairScrapers
+// must only be called from mainLoop
+func (s *BitMartScraper) cleanup(err error) {
+	s.pairScrapers.Range(func(k, v interface{}) bool {
+		for ps := range v.(bitMartPairScraperSet) {
+			ps.closed = true
+		}
+		s.pairScrapers.Delete(k)
+		return true
+	})
+	if err != nil {
+		s.setError(err)
+	}
+	s.close()
+	close(s.shutdownDone)
+}
+
+func (s *BitMartScraper) isClosed() bool {
+	s.closedMutex.RLock()
+	defer s.closedMutex.RUnlock()
+	return s.closed
+}
+
+func (s *BitMartScraper) close() {
+	s.closedMutex.Lock()
+	defer s.closedMutex.Unlock()
+	s.closed = true
+}
+
+func (s *BitMartScraper) error() error {
+	s.errMutex.RLock()
+	defer s.errMutex.RUnlock()
+	return s.err
+}
+
+func (s *BitMartScraper) setError(err error) {
+	s.errMutex.Lock()
+	defer s.errMutex.Unlock()
+	s.err = err
+}
+
+func (s *BitMartScraper) subscribe(foreignName string, id int) error {
+	topic := fmt.Sprintf("%s:%s", bitMartWSSpotTradingTopic, foreignName)
+	s.rl.Take()
+	if err := s.wsClient[id].WriteJSON(BitmartWsRequest{
+		Op:   bitMartWSOpSubscribe,
+		Args: []string{topic},
+	}); err != nil {
+		return err
+	}
+	s.countTopic[id]++
+	if s.lastUsedConnection == bitMartMaxConnections-1 {
+		s.lastUsedConnection = 0
+	} else {
+		s.lastUsedConnection++
+	}
+	return nil
+}
+
+func (s *BitMartScraper) unsubscribe(foreignName string) error {
+	if id, ok := s.pairSubscriptions.Load(foreignName); ok {
+		if err := s.wsClient[id.(int)].WriteJSON(BitmartWsRequest{
+			Op:   bitMartWSOpUnsubscribe,
+			Args: []string{fmt.Sprintf("%s:%s", bitMartWSSpotTradingTopic, foreignName)},
+		}); err != nil {
+			return err
+		}
+		s.pairSubscriptions.Delete(foreignName)
+		s.countTopic[id.(int)]--
+		return nil
+	} else {
+		return errors.New("subscription id not found")
+	}
+}


### PR DESCRIPTION
Adds BitMart exchange scraper, this closes issue [Write A Trades Scraper For BitMart Exchange #627](https://github.com/diadata-org/diadata/issues/627).

## Changes

* Config files for updated markets and exchange;
    * `config/exchanges/exchanges.json`
    * `config/BitMart.json`
    * `config/gitcoinverified/BitMart.json`
* Scraper config (`pkg/dia/Config.go`) and interface file (`pkg/dia/scraper/exchange-scrapers/APIScraper.go`) ;
* Scraper `pkg/dia/scraper/exchange-scrapers/BitMartScraper.go`;
    * [X] Support for closing and unsubscribe a pair scraper;
    * [X] 10x concurrent WS connections;
    * [X] Failure handling with retries;
    * [X] Blocking requests with a proper rate limit.

Signed-off-by: Alexandre Ferreira <alexjorgef@protonmail.com>