### PR TITLE
fix: add rpc_endpoint_solana to get token_names

### DIFF
--- a/pkg/dia/service/assetservice/source/serum.go
+++ b/pkg/dia/service/assetservice/source/serum.go
@@ -20,8 +20,8 @@ type SerumPair struct {
 
 const (
 	// Public Solana clients.
-	rpcEndpointSolana         = ""
-	dexProgramAddress         = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin" // refer - https://github.com/project-serum/serum-dex
+	rpcEndpointSolana         = "https://try-rpc.mainnet.solana.blockdaemon.tech" // refer - https://try.blockdaemon.com/rpc/solana/
+	dexProgramAddress         = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"    // refer - https://github.com/project-serum/serum-dex
 	nameServiceProgramAddress = "namesLPneVptA9Z5rqUDD9tMTWEJwofgaYwp8cawRkX"
 	dotTokenTLD               = "6NSu2tci4apRKQtt257bAVcvqYjB3zV2H1dWo56vgpa6"
 	marketDataSize            = 388

--- a/pkg/dia/service/assetservice/source/serum_test.go
+++ b/pkg/dia/service/assetservice/source/serum_test.go
@@ -1,0 +1,26 @@
+package source
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/diadata-org/diadata/pkg/dia"
+)
+
+func TestSerum(t *testing.T) {
+	service := NewSerumAssetSource(dia.Exchange{})
+	names, err := service.getTokenNames()
+	fmt.Println(err)
+
+	i := 0
+	for k, v := range names {
+		i++
+		fmt.Println(i)
+		fmt.Println(k)
+		fmt.Println("name:", v.name)
+		fmt.Println("symbol:", v.symbol)
+		fmt.Println("decimals:", v.decimals)
+		fmt.Println("mint:", v.mint)
+		fmt.Println("")
+	}
+}


### PR DESCRIPTION
Add the solana endpoint to get token_names.
We can verify the functionality with the tests in pkg/dia/service/assetservice/source/serum_test.go