### PR TITLE
downgrade InfluxDB to v1.8 on local container

### DIFF
--- a/deployments/local/exchange-scraper/docker-compose.yml
+++ b/deployments/local/exchange-scraper/docker-compose.yml
@@ -5,17 +5,9 @@ services:
     ports:
       - "6379:6379"
   influxdb:
-    image: influxdb:2.0
+    image: influxdb:1.8
     ports:
       - "8086:8086"
-  influxdb_cli:
-    links:
-      - influxdb
-    image: influxdb:2.0
-    entrypoint: influx setup --bucket test_bucket -t test_token -o test_org --username test --password testtest --host http://127.0.0.1:8086 -f
-    restart: on-failure:20
-    depends_on:
-      - influxdb
   postgres:
     image: postgres
     restart: always


### PR DESCRIPTION
With this, a local deployment using docker-compose will use InfluxDB v1.8 instead of the v2.0 version.

Using v2 ended with some errors. For example, InfluxQL queries with the `CREATE` identifier don't exist ([ref](https://docs.influxdata.com/influxdb/v2.6/query-data/influxql/#unsupported-influxql-queries)), basic authentication (username/password) is no longer supported on query's endpoint ([ref](https://docs.influxdata.com/influxdb/v2.6/api/#tag/Query)).