### PR TITLE
Use kafka writer and allow auto topic creation

### DIFF
--- a/pkg/dia/helpers/kafkaHelper/Kafka.go
+++ b/pkg/dia/helpers/kafkaHelper/Kafka.go
@@ -149,33 +149,36 @@ func ReadOffsetWithRetryOnError(topic int) (offset int64) {
 }
 
 func NewWriter(topic int) *kafka.Writer {
-	return kafka.NewWriter(kafka.WriterConfig{
-		Brokers:  KafkaConfig.KafkaUrl,
-		Topic:    getTopic(topic),
-		Balancer: &kafka.LeastBytes{},
-		Async:    true,
-	})
+	return &kafka.Writer{
+		Addr:                   kafka.TCP(KafkaConfig.KafkaUrl[0]),
+		Topic:                  getTopic(topic),
+		Balancer:               &kafka.LeastBytes{},
+		Async:                  true,
+		AllowAutoTopicCreation: true,
+	}
 }
 
 func NewSyncWriter(topic int) *kafka.Writer {
-	return kafka.NewWriter(kafka.WriterConfig{
-		Brokers:    KafkaConfig.KafkaUrl,
-		Topic:      getTopic(topic),
-		Balancer:   &kafka.LeastBytes{},
-		Async:      false,
-		BatchBytes: 1e9, // 1GB
-	})
+	return &kafka.Writer{
+		Addr:                   kafka.TCP(KafkaConfig.KafkaUrl[0]),
+		Topic:                  getTopic(topic),
+		Balancer:               &kafka.LeastBytes{},
+		Async:                  false,
+		BatchBytes:             1e9, // 1GB
+		AllowAutoTopicCreation: true,
+	}
 }
 
 func NewSyncWriterWithCompression(topic int) *kafka.Writer {
-	return kafka.NewWriter(kafka.WriterConfig{
-		Brokers:          KafkaConfig.KafkaUrl,
-		Topic:            getTopic(topic),
-		Balancer:         &kafka.LeastBytes{},
-		Async:            false,
-		BatchBytes:       1e9, // 1GB
-		CompressionCodec: &compress.GzipCodec,
-	})
+	return &kafka.Writer{
+		Addr:                   kafka.TCP(KafkaConfig.KafkaUrl[0]),
+		Topic:                  getTopic(topic),
+		Balancer:               &kafka.LeastBytes{},
+		Async:                  false,
+		BatchBytes:             1e9, // 1GB
+		Compression:            compress.Gzip,
+		AllowAutoTopicCreation: true,
+	}
 }
 
 func NewReader(topic int) *kafka.Reader {


### PR DESCRIPTION
Using a local environment I notice Kafka is returning an error message when writing to a topic: `Unknown Topic Or Partition: the request is for a topic or partition that does not exist on this broker`. This issue seems similar to [segmentio/kafka-go#683](https://github.com/segmentio/kafka-go/issues/683), and I'm using `wurstmeister/kafka:latest` and `wurstmeister/zookeeper:latest` images for testing.

This will allow Kafka helper to auto-create topics when using [Writer](https://pkg.go.dev/github.com/segmentio/kafka-go#Writer).