### PR TITLE
fix(ci): map diaFxOracleV2MultiupdateService to nexus/oracles ECR repo

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -280,6 +280,9 @@ jobs:
             diaoraclev2multiupdateservice)
               ecr_repo="nexus/oracles/diaoraclev2multiupdateservice"
               ;;
+            diafxoraclev2multiupdateservice)
+              ecr_repo="nexus/oracles/diafxoraclev2multiupdateservice"
+              ;;
             *)
               # Default: all other services go to nexus/services/
               ecr_repo="nexus/services/${service_name_lower}"

--- a/.github/workflows/test-aws-ecr-deployment.yml
+++ b/.github/workflows/test-aws-ecr-deployment.yml
@@ -282,6 +282,9 @@ jobs:
             diaoraclev2multiupdateservice)
               ecr_repo="nexus/oracles/diaoraclev2multiupdateservice"
               ;;
+            diafxoraclev2multiupdateservice)
+              ecr_repo="nexus/oracles/diafxoraclev2multiupdateservice"
+              ;;
             *)
               # Default: all other services go to nexus/services/
               ecr_repo="nexus/services/${service_name_lower}"


### PR DESCRIPTION
## Summary
Adds the missing ECR repo mapping for `diafxoraclev2multiupdateservice` in production-deployment and test-aws-ecr-deployment. Without it the service falls into the default `nexus/services/` case and the push fails (repo does not exist) — this is what failed the production run after #1295 renamed the service. The fx feeders pull from `nexus/oracles/diafxoraclev2multiupdateservice`, which is now terraform-managed (aws-cluster #191).

## Test plan
- actionlint clean on both workflows
- Next fx service release pushes to nexus/oracles/diafxoraclev2multiupdateservice